### PR TITLE
Add custom error types and improve error handling

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -1,0 +1,133 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tommyt6073@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package api
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v59/github"
+)
+
+// UnauthorizedError indicates 401 Unauthorized response
+type UnauthorizedError struct{}
+
+func (e *UnauthorizedError) Error() string {
+	return "unauthorized"
+}
+
+// ForbiddenError indicates 403 Forbidden response
+type ForbiddenError struct{}
+
+func (e *ForbiddenError) Error() string {
+	return "forbidden"
+}
+
+// NotFoundError indicates 404 Not Found response
+type NotFoundError struct {
+	resource string
+}
+
+func (e *NotFoundError) Error() string {
+	if e.resource == "" {
+		return "not found"
+	}
+	return fmt.Sprintf("%s not found", e.resource)
+}
+
+// RateLimitError indicates 429 Too Many Requests response
+type RateLimitError struct{}
+
+func (e *RateLimitError) Error() string {
+	return "rate limit exceeded"
+}
+
+// AlreadyExistsError indicates resource already exists
+type AlreadyExistsError struct {
+	resource string
+}
+
+func (e *AlreadyExistsError) Error() string {
+	if e.resource == "" {
+		return "already exists"
+	}
+	return fmt.Sprintf("%s already exists", e.resource)
+}
+
+// Helper functions to check error types
+func IsNotFound(err error) bool {
+	var notFoundErr *NotFoundError
+	return errors.As(err, &notFoundErr)
+}
+
+func IsUnauthorized(err error) bool {
+	var unauthorizedErr *UnauthorizedError
+	return errors.As(err, &unauthorizedErr)
+}
+
+func IsForbidden(err error) bool {
+	var forbiddenErr *ForbiddenError
+	return errors.As(err, &forbiddenErr)
+}
+
+func IsRateLimit(err error) bool {
+	var rateLimitErr *RateLimitError
+	return errors.As(err, &rateLimitErr)
+}
+
+func IsAlreadyExists(err error) bool {
+	var alreadyExistsErr *AlreadyExistsError
+	return errors.As(err, &alreadyExistsErr)
+}
+
+// wrapGitHubError converts GitHub API errors to our custom error types
+func wrapGitHubError(err error, resource string) error {
+	if err == nil {
+		return nil
+	}
+
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) {
+		switch ghErr.Response.StatusCode {
+		case 401:
+			return &UnauthorizedError{}
+		case 403:
+			return &ForbiddenError{}
+		case 404:
+			return &NotFoundError{resource: resource}
+		case 429:
+			return &RateLimitError{}
+		case 422:
+			if strings.Contains(err.Error(), "already_exists") {
+				return &AlreadyExistsError{resource: resource}
+			}
+			return fmt.Errorf("GitHub API error (status %d): %s", ghErr.Response.StatusCode, ghErr.Message)
+		default:
+			// Return the original error with status code for other cases
+			return fmt.Errorf("GitHub API error (status %d): %s", ghErr.Response.StatusCode, ghErr.Message)
+		}
+	}
+
+	// If it's not a GitHub error response, return the original error
+	return err
+}

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tommyt6073@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v59/github"
+)
+
+func TestWrapGitHubError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		resource string
+		want     error
+		wantMsg  string
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			resource: "test resource",
+			want:     nil,
+			wantMsg:  "",
+		},
+		{
+			name: "401 unauthorized",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: 401},
+				Message:  "Bad credentials",
+			},
+			resource: "test resource",
+			want:     &UnauthorizedError{},
+			wantMsg:  "unauthorized",
+		},
+		{
+			name: "403 forbidden",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: 403},
+				Message:  "Resource not accessible",
+			},
+			resource: "test resource",
+			want:     &ForbiddenError{},
+			wantMsg:  "forbidden",
+		},
+		{
+			name: "404 not found with resource",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: 404},
+				Message:  "Not Found",
+			},
+			resource: "repository \"owner/repo\"",
+			want:     &NotFoundError{resource: "repository \"owner/repo\""},
+			wantMsg:  "repository \"owner/repo\" not found",
+		},
+		{
+			name: "429 rate limit",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: 429},
+				Message:  "API rate limit exceeded",
+			},
+			resource: "test resource",
+			want:     &RateLimitError{},
+			wantMsg:  "rate limit exceeded",
+		},
+		{
+			name: "422 already exists",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: 422},
+				Message:  "Validation Failed",
+				Errors: []github.Error{
+					{Code: "already_exists"},
+				},
+			},
+			resource: "label \"bug\" on \"owner/repo\"",
+			want:     &AlreadyExistsError{resource: "label \"bug\" on \"owner/repo\""},
+			wantMsg:  "label \"bug\" on \"owner/repo\" already exists",
+		},
+		{
+			name: "422 other validation error",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: 422},
+				Message:  "Validation Failed",
+				Errors: []github.Error{
+					{Code: "invalid"},
+				},
+			},
+			resource: "test resource",
+			want:     fmt.Errorf("GitHub API error (status 422): Validation Failed"),
+			wantMsg:  "GitHub API error (status 422): Validation Failed",
+		},
+		{
+			name: "500 server error",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: 500},
+				Message:  "Internal Server Error",
+			},
+			resource: "test resource",
+			want:     fmt.Errorf("GitHub API error (status 500): Internal Server Error"),
+			wantMsg:  "GitHub API error (status 500): Internal Server Error",
+		},
+		{
+			name:     "non-GitHub error",
+			err:      errors.New("network error"),
+			resource: "test resource",
+			want:     errors.New("network error"),
+			wantMsg:  "network error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapGitHubError(tt.err, tt.resource)
+
+			// Check if error is nil
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("wrapGitHubError() = %v, want nil", got)
+				}
+				return
+			}
+
+			// Check error message
+			if got.Error() != tt.wantMsg {
+				t.Errorf("wrapGitHubError() error message = %v, want %v", got.Error(), tt.wantMsg)
+			}
+
+			// Check error type for custom errors
+			switch want := tt.want.(type) {
+			case *UnauthorizedError:
+				if _, ok := got.(*UnauthorizedError); !ok {
+					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
+				}
+			case *ForbiddenError:
+				if _, ok := got.(*ForbiddenError); !ok {
+					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
+				}
+			case *NotFoundError:
+				gotErr, ok := got.(*NotFoundError)
+				if !ok {
+					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
+				} else if gotErr.resource != want.resource {
+					t.Errorf("NotFoundError.resource = %v, want %v", gotErr.resource, want.resource)
+				}
+			case *RateLimitError:
+				if _, ok := got.(*RateLimitError); !ok {
+					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
+				}
+			case *AlreadyExistsError:
+				gotErr, ok := got.(*AlreadyExistsError)
+				if !ok {
+					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
+				} else if gotErr.resource != want.resource {
+					t.Errorf("AlreadyExistsError.resource = %v, want %v", gotErr.resource, want.resource)
+				}
+			}
+		})
+	}
+}
+
+func TestHelperFunctions(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		checkFn  func(error) bool
+		expected bool
+	}{
+		{
+			name:     "IsNotFound with NotFoundError",
+			err:      &NotFoundError{resource: "test"},
+			checkFn:  IsNotFound,
+			expected: true,
+		},
+		{
+			name:     "IsNotFound with other error",
+			err:      &UnauthorizedError{},
+			checkFn:  IsNotFound,
+			expected: false,
+		},
+		{
+			name:     "IsUnauthorized with UnauthorizedError",
+			err:      &UnauthorizedError{},
+			checkFn:  IsUnauthorized,
+			expected: true,
+		},
+		{
+			name:     "IsUnauthorized with other error",
+			err:      &ForbiddenError{},
+			checkFn:  IsUnauthorized,
+			expected: false,
+		},
+		{
+			name:     "IsForbidden with ForbiddenError",
+			err:      &ForbiddenError{},
+			checkFn:  IsForbidden,
+			expected: true,
+		},
+		{
+			name:     "IsForbidden with other error",
+			err:      &RateLimitError{},
+			checkFn:  IsForbidden,
+			expected: false,
+		},
+		{
+			name:     "IsRateLimit with RateLimitError",
+			err:      &RateLimitError{},
+			checkFn:  IsRateLimit,
+			expected: true,
+		},
+		{
+			name:     "IsRateLimit with other error",
+			err:      &AlreadyExistsError{resource: "test"},
+			checkFn:  IsRateLimit,
+			expected: false,
+		},
+		{
+			name:     "IsAlreadyExists with AlreadyExistsError",
+			err:      &AlreadyExistsError{resource: "test"},
+			checkFn:  IsAlreadyExists,
+			expected: true,
+		},
+		{
+			name:     "IsAlreadyExists with other error",
+			err:      &NotFoundError{resource: "test"},
+			checkFn:  IsAlreadyExists,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.checkFn(tt.err); got != tt.expected {
+				t.Errorf("%s() = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestErrorMessages(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantMsg string
+	}{
+		{
+			name:    "UnauthorizedError",
+			err:     &UnauthorizedError{},
+			wantMsg: "unauthorized",
+		},
+		{
+			name:    "ForbiddenError",
+			err:     &ForbiddenError{},
+			wantMsg: "forbidden",
+		},
+		{
+			name:    "NotFoundError with resource",
+			err:     &NotFoundError{resource: "label \"bug\" on \"owner/repo\""},
+			wantMsg: "label \"bug\" on \"owner/repo\" not found",
+		},
+		{
+			name:    "NotFoundError without resource",
+			err:     &NotFoundError{resource: ""},
+			wantMsg: "not found",
+		},
+		{
+			name:    "RateLimitError",
+			err:     &RateLimitError{},
+			wantMsg: "rate limit exceeded",
+		},
+		{
+			name:    "AlreadyExistsError with resource",
+			err:     &AlreadyExistsError{resource: "label \"bug\" on \"owner/repo\""},
+			wantMsg: "label \"bug\" on \"owner/repo\" already exists",
+		},
+		{
+			name:    "AlreadyExistsError without resource",
+			err:     &AlreadyExistsError{resource: ""},
+			wantMsg: "already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.wantMsg {
+				t.Errorf("Error() = %v, want %v", got, tt.wantMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Introduce custom error types (UnauthorizedError, ForbiddenError, NotFoundError, RateLimitError, AlreadyExistsError)
- Add wrapGitHubError function to convert GitHub API errors to custom types
- Update API methods to use wrapGitHubError for consistent error messages
- Add comprehensive tests for error handling including 401, 403, 404, 429, and 422 errors
- Improve error messages to be more user-friendly (e.g., label "bug" on "owner/repo" already exists)
- Handle 404 errors intelligently in CreateLabel to distinguish between repository not found and other cases

🤖 Generated with [Claude Code](https://claude.ai/code)