### PR TITLE
Improve error handling and output clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,14 @@ The codebase follows a clean layered architecture:
    - Contains the core functionality for label operations
    - Handles batch operations across multiple repositories
    - Supports dry-run mode for all operations
+   - Uses `ExecutionResult` to collect errors and provide operation summaries
+   - Implements smart sync logic that diffs existing labels and updates only as needed
 
 3. **api/** - GitHub API client wrapper
    - Defines `APIClient` interface for testability
    - Wraps google/go-github client
    - All API operations go through this layer
+   - Provides custom error types (`NotFoundError`, `ForbiddenError`, etc.) for better error handling
 
 4. **parser/** - Command-line option parsing
    - Handles file-based input for labels and repositories
@@ -74,13 +77,19 @@ func TestFunctionName(t *testing.T) {
 ## Key Interfaces
 
 - `api.APIClient` - Main interface for GitHub API operations
+  - `CreateLabel(label option.Label, repo option.Repo) error`
+  - `UpdateLabel(label option.Label, repo option.Repo) error`
+  - `DeleteLabel(label string, repo option.Repo) error`
+  - `ListLabels(repo option.Repo) ([]string, error)`
 - All executor functions accept this interface for dependency injection
 
 ## Error Handling
 
 - Operations continue even if individual label operations fail
-- Errors are collected and reported at the end
+- Errors are collected using `ExecutionResult` structure
+- Summary is displayed at the end showing success/failure counts
 - Exit code 1 if any operations failed
+- Custom error types for common GitHub API errors (404, 403, etc.)
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ The codebase follows a clean layered architecture:
    - Defines `APIClient` interface for testability
    - Wraps google/go-github client
    - All API operations go through this layer
-   - Provides custom error types (`NotFoundError`, `ForbiddenError`, etc.) for better error handling
+   - Provides custom error types (`NotFoundError`, `ForbiddenError`, etc.) with `ResourceType` enum for better error categorization
+   - Error messages are simplified (e.g., "repository not found" instead of full details)
 
 4. **parser/** - Command-line option parsing
    - Handles file-based input for labels and repositories
@@ -87,9 +88,11 @@ func TestFunctionName(t *testing.T) {
 
 - Operations continue even if individual label operations fail
 - Errors are collected using `ExecutionResult` structure
-- Summary is displayed at the end showing success/failure counts
+- Summary is displayed at the end showing success/failure counts (format: "Summary: X repositories succeeded, Y failed")
 - Exit code 1 if any operations failed
-- Custom error types for common GitHub API errors (404, 403, etc.)
+- Custom error types for common GitHub API errors (404, 403, etc.) with `ResourceType` enum to distinguish between repository and label errors
+- Simplified error messages without redundant details (e.g., "repository not found" instead of "repository 'owner/repo' not found")
+- Command usage is not displayed for runtime errors (only for argument/flag errors)
 
 ## CI/CD
 

--- a/api/api.go
+++ b/api/api.go
@@ -34,6 +34,7 @@ import (
 // APIClient is a interface for the API client
 type APIClient interface {
 	CreateLabel(label option.Label, repo option.Repo) error
+	UpdateLabel(label option.Label, repo option.Repo) error
 	DeleteLabel(label string, repo option.Repo) error
 	ListLabels(repo option.Repo) ([]string, error)
 }
@@ -66,6 +67,24 @@ func (a *API) CreateLabel(label option.Label, repo option.Repo) error {
 			resource := fmt.Sprintf("repository %q", fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
 			return wrapGitHubError(err, resource)
 		}
+		resource := fmt.Sprintf("label %q on %q", label.Name, fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
+		return wrapGitHubError(err, resource)
+	}
+
+	return nil
+}
+
+// UpdateLabel updates an existing label in the repository
+func (a *API) UpdateLabel(label option.Label, repo option.Repo) error {
+	githubLabel := &github.Label{
+		Name:        github.String(label.Name),
+		Description: github.String(label.Description),
+		Color:       github.String(label.Color),
+	}
+
+	_, _, err := a.client.Issues.EditLabel(context.Background(), repo.Owner, repo.Repo, label.Name, githubLabel)
+
+	if err != nil {
 		resource := fmt.Sprintf("label %q on %q", label.Name, fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
 		return wrapGitHubError(err, resource)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -24,7 +24,6 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/v59/github"
@@ -64,11 +63,9 @@ func (a *API) CreateLabel(label option.Label, repo option.Repo) error {
 	if err != nil {
 		var ghErr *github.ErrorResponse
 		if errors.As(err, &ghErr) && ghErr.Response.StatusCode == 404 {
-			resource := fmt.Sprintf("repository %q", fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
-			return wrapGitHubError(err, resource)
+			return wrapGitHubError(err, ResourceTypeRepository)
 		}
-		resource := fmt.Sprintf("label %q on %q", label.Name, fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
-		return wrapGitHubError(err, resource)
+		return wrapGitHubError(err, ResourceTypeLabel)
 	}
 
 	return nil
@@ -85,8 +82,7 @@ func (a *API) UpdateLabel(label option.Label, repo option.Repo) error {
 	_, _, err := a.client.Issues.EditLabel(context.Background(), repo.Owner, repo.Repo, label.Name, githubLabel)
 
 	if err != nil {
-		resource := fmt.Sprintf("label %q on %q", label.Name, fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
-		return wrapGitHubError(err, resource)
+		return wrapGitHubError(err, ResourceTypeLabel)
 	}
 
 	return nil
@@ -97,8 +93,7 @@ func (a *API) DeleteLabel(label string, repo option.Repo) error {
 	_, err := a.client.Issues.DeleteLabel(context.Background(), repo.Owner, repo.Repo, label)
 
 	if err != nil {
-		resource := fmt.Sprintf("label %q on %q", label, fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
-		return wrapGitHubError(err, resource)
+		return wrapGitHubError(err, ResourceTypeLabel)
 	}
 
 	return nil
@@ -109,8 +104,7 @@ func (a *API) ListLabels(repo option.Repo) ([]string, error) {
 	labels, _, err := a.client.Issues.ListLabels(context.Background(), repo.Owner, repo.Repo, nil)
 
 	if err != nil {
-		resource := fmt.Sprintf("repository %q", fmt.Sprintf("%s/%s", repo.Owner, repo.Repo))
-		return nil, wrapGitHubError(err, resource)
+		return nil, wrapGitHubError(err, ResourceTypeRepository)
 	}
 
 	var labelNames []string

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -139,7 +139,7 @@ func TestCreateLabel(t *testing.T) {
 					JSON(map[string]string{"message": "Not Found"})
 			},
 			wantErr:    true,
-			wantErrMsg: "repository \"tnagatomi/non-existent-repo\" not found",
+			wantErrMsg: "repository not found",
 		},
 		{
 			name: "already exists",
@@ -169,7 +169,7 @@ func TestCreateLabel(t *testing.T) {
 					})
 			},
 			wantErr:    true,
-			wantErrMsg: "label \"bug\" on \"tnagatomi/mock-repo\" already exists",
+			wantErrMsg: "label already exists",
 		},
 	}
 
@@ -244,7 +244,7 @@ func TestDeleteLabel(t *testing.T) {
 					JSON(map[string]string{"message": "Not Found"})
 			},
 			wantErr: true,
-			wantErrMsg: "label \"bug\" on \"tnagatomi/mock-repo\" not found",
+			wantErrMsg: "label not found",
 		},
 	}
 
@@ -331,7 +331,7 @@ func TestUpdateLabel(t *testing.T) {
 					JSON(map[string]string{"message": "Not Found"})
 			},
 			wantErr:    true,
-			wantErrMsg: "label \"nonexistent\" on \"tnagatomi/mock-repo\" not found",
+			wantErrMsg: "label not found",
 		},
 	}
 
@@ -424,7 +424,7 @@ func TestListLabels(t *testing.T) {
 			},
 			want:       nil,
 			wantErr:    true,
-			wantErrMsg: "repository \"tnagatomi/non-existent-repo\" not found",
+			wantErrMsg: "repository not found",
 		},
 	}
 

--- a/api/errors.go
+++ b/api/errors.go
@@ -45,14 +45,14 @@ func (e *ForbiddenError) Error() string {
 
 // NotFoundError indicates 404 Not Found response
 type NotFoundError struct {
-	resource string
+	Resource string
 }
 
 func (e *NotFoundError) Error() string {
-	if e.resource == "" {
+	if e.Resource == "" {
 		return "not found"
 	}
-	return fmt.Sprintf("%s not found", e.resource)
+	return fmt.Sprintf("%s not found", e.Resource)
 }
 
 // RateLimitError indicates 429 Too Many Requests response
@@ -64,14 +64,14 @@ func (e *RateLimitError) Error() string {
 
 // AlreadyExistsError indicates resource already exists
 type AlreadyExistsError struct {
-	resource string
+	Resource string
 }
 
 func (e *AlreadyExistsError) Error() string {
-	if e.resource == "" {
+	if e.Resource == "" {
 		return "already exists"
 	}
-	return fmt.Sprintf("%s already exists", e.resource)
+	return fmt.Sprintf("%s already exists", e.Resource)
 }
 
 // Helper functions to check error types
@@ -114,12 +114,12 @@ func wrapGitHubError(err error, resource string) error {
 		case 403:
 			return &ForbiddenError{}
 		case 404:
-			return &NotFoundError{resource: resource}
+			return &NotFoundError{Resource: resource}
 		case 429:
 			return &RateLimitError{}
 		case 422:
 			if strings.Contains(err.Error(), "already_exists") {
-				return &AlreadyExistsError{resource: resource}
+				return &AlreadyExistsError{Resource: resource}
 			}
 			return fmt.Errorf("GitHub API error (status %d): %s", ghErr.Response.StatusCode, ghErr.Message)
 		default:

--- a/api/errors.go
+++ b/api/errors.go
@@ -43,16 +43,24 @@ func (e *ForbiddenError) Error() string {
 	return "forbidden"
 }
 
+// ResourceType represents the type of resource
+type ResourceType string
+
+const (
+	ResourceTypeRepository ResourceType = "repository"
+	ResourceTypeLabel      ResourceType = "label"
+)
+
 // NotFoundError indicates 404 Not Found response
 type NotFoundError struct {
-	Resource string
+	ResourceType ResourceType
 }
 
 func (e *NotFoundError) Error() string {
-	if e.Resource == "" {
+	if e.ResourceType == "" {
 		return "not found"
 	}
-	return fmt.Sprintf("%s not found", e.Resource)
+	return fmt.Sprintf("%s not found", e.ResourceType)
 }
 
 // RateLimitError indicates 429 Too Many Requests response
@@ -64,14 +72,14 @@ func (e *RateLimitError) Error() string {
 
 // AlreadyExistsError indicates resource already exists
 type AlreadyExistsError struct {
-	Resource string
+	ResourceType ResourceType
 }
 
 func (e *AlreadyExistsError) Error() string {
-	if e.Resource == "" {
+	if e.ResourceType == "" {
 		return "already exists"
 	}
-	return fmt.Sprintf("%s already exists", e.Resource)
+	return fmt.Sprintf("%s already exists", e.ResourceType)
 }
 
 // Helper functions to check error types
@@ -101,7 +109,7 @@ func IsAlreadyExists(err error) bool {
 }
 
 // wrapGitHubError converts GitHub API errors to our custom error types
-func wrapGitHubError(err error, resource string) error {
+func wrapGitHubError(err error, resourceType ResourceType) error {
 	if err == nil {
 		return nil
 	}
@@ -114,12 +122,12 @@ func wrapGitHubError(err error, resource string) error {
 		case 403:
 			return &ForbiddenError{}
 		case 404:
-			return &NotFoundError{Resource: resource}
+			return &NotFoundError{ResourceType: resourceType}
 		case 429:
 			return &RateLimitError{}
 		case 422:
 			if strings.Contains(err.Error(), "already_exists") {
-				return &AlreadyExistsError{Resource: resource}
+				return &AlreadyExistsError{ResourceType: resourceType}
 			}
 			return fmt.Errorf("GitHub API error (status %d): %s", ghErr.Response.StatusCode, ghErr.Message)
 		default:

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -72,7 +72,7 @@ func TestWrapGitHubError(t *testing.T) {
 				Message:  "Not Found",
 			},
 			resource: "repository \"owner/repo\"",
-			want:     &NotFoundError{resource: "repository \"owner/repo\""},
+			want:     &NotFoundError{Resource: "repository \"owner/repo\""},
 			wantMsg:  "repository \"owner/repo\" not found",
 		},
 		{
@@ -95,7 +95,7 @@ func TestWrapGitHubError(t *testing.T) {
 				},
 			},
 			resource: "label \"bug\" on \"owner/repo\"",
-			want:     &AlreadyExistsError{resource: "label \"bug\" on \"owner/repo\""},
+			want:     &AlreadyExistsError{Resource: "label \"bug\" on \"owner/repo\""},
 			wantMsg:  "label \"bug\" on \"owner/repo\" already exists",
 		},
 		{
@@ -161,8 +161,8 @@ func TestWrapGitHubError(t *testing.T) {
 				gotErr, ok := got.(*NotFoundError)
 				if !ok {
 					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
-				} else if gotErr.resource != want.resource {
-					t.Errorf("NotFoundError.resource = %v, want %v", gotErr.resource, want.resource)
+				} else if gotErr.Resource != want.Resource {
+					t.Errorf("NotFoundError.Resource = %v, want %v", gotErr.Resource, want.Resource)
 				}
 			case *RateLimitError:
 				if _, ok := got.(*RateLimitError); !ok {
@@ -172,8 +172,8 @@ func TestWrapGitHubError(t *testing.T) {
 				gotErr, ok := got.(*AlreadyExistsError)
 				if !ok {
 					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
-				} else if gotErr.resource != want.resource {
-					t.Errorf("AlreadyExistsError.resource = %v, want %v", gotErr.resource, want.resource)
+				} else if gotErr.Resource != want.Resource {
+					t.Errorf("AlreadyExistsError.resource = %v, want %v", gotErr.Resource, want.Resource)
 				}
 			}
 		})
@@ -189,7 +189,7 @@ func TestHelperFunctions(t *testing.T) {
 	}{
 		{
 			name:     "IsNotFound with NotFoundError",
-			err:      &NotFoundError{resource: "test"},
+			err:      &NotFoundError{Resource: "test"},
 			checkFn:  IsNotFound,
 			expected: true,
 		},
@@ -231,19 +231,19 @@ func TestHelperFunctions(t *testing.T) {
 		},
 		{
 			name:     "IsRateLimit with other error",
-			err:      &AlreadyExistsError{resource: "test"},
+			err:      &AlreadyExistsError{Resource: "test"},
 			checkFn:  IsRateLimit,
 			expected: false,
 		},
 		{
 			name:     "IsAlreadyExists with AlreadyExistsError",
-			err:      &AlreadyExistsError{resource: "test"},
+			err:      &AlreadyExistsError{Resource: "test"},
 			checkFn:  IsAlreadyExists,
 			expected: true,
 		},
 		{
 			name:     "IsAlreadyExists with other error",
-			err:      &NotFoundError{resource: "test"},
+			err:      &NotFoundError{Resource: "test"},
 			checkFn:  IsAlreadyExists,
 			expected: false,
 		},
@@ -276,12 +276,12 @@ func TestErrorMessages(t *testing.T) {
 		},
 		{
 			name:    "NotFoundError with resource",
-			err:     &NotFoundError{resource: "label \"bug\" on \"owner/repo\""},
+			err:     &NotFoundError{Resource: "label \"bug\" on \"owner/repo\""},
 			wantMsg: "label \"bug\" on \"owner/repo\" not found",
 		},
 		{
 			name:    "NotFoundError without resource",
-			err:     &NotFoundError{resource: ""},
+			err:     &NotFoundError{Resource: ""},
 			wantMsg: "not found",
 		},
 		{
@@ -291,12 +291,12 @@ func TestErrorMessages(t *testing.T) {
 		},
 		{
 			name:    "AlreadyExistsError with resource",
-			err:     &AlreadyExistsError{resource: "label \"bug\" on \"owner/repo\""},
+			err:     &AlreadyExistsError{Resource: "label \"bug\" on \"owner/repo\""},
 			wantMsg: "label \"bug\" on \"owner/repo\" already exists",
 		},
 		{
 			name:    "AlreadyExistsError without resource",
-			err:     &AlreadyExistsError{resource: ""},
+			err:     &AlreadyExistsError{Resource: ""},
 			wantMsg: "already exists",
 		},
 	}

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -32,16 +32,16 @@ import (
 
 func TestWrapGitHubError(t *testing.T) {
 	tests := []struct {
-		name     string
-		err      error
-		resource string
-		want     error
-		wantMsg  string
+		name         string
+		err          error
+		resourceType ResourceType
+		want         error
+		wantMsg      string
 	}{
 		{
 			name:     "nil error",
 			err:      nil,
-			resource: "test resource",
+			resourceType: ResourceTypeLabel,
 			want:     nil,
 			wantMsg:  "",
 		},
@@ -51,7 +51,7 @@ func TestWrapGitHubError(t *testing.T) {
 				Response: &http.Response{StatusCode: 401},
 				Message:  "Bad credentials",
 			},
-			resource: "test resource",
+			resourceType: ResourceTypeLabel,
 			want:     &UnauthorizedError{},
 			wantMsg:  "unauthorized",
 		},
@@ -61,7 +61,7 @@ func TestWrapGitHubError(t *testing.T) {
 				Response: &http.Response{StatusCode: 403},
 				Message:  "Resource not accessible",
 			},
-			resource: "test resource",
+			resourceType: ResourceTypeLabel,
 			want:     &ForbiddenError{},
 			wantMsg:  "forbidden",
 		},
@@ -71,9 +71,9 @@ func TestWrapGitHubError(t *testing.T) {
 				Response: &http.Response{StatusCode: 404},
 				Message:  "Not Found",
 			},
-			resource: "repository \"owner/repo\"",
-			want:     &NotFoundError{Resource: "repository \"owner/repo\""},
-			wantMsg:  "repository \"owner/repo\" not found",
+			resourceType: ResourceTypeRepository,
+			want:         &NotFoundError{ResourceType: ResourceTypeRepository},
+			wantMsg:      "repository not found",
 		},
 		{
 			name: "429 rate limit",
@@ -81,7 +81,7 @@ func TestWrapGitHubError(t *testing.T) {
 				Response: &http.Response{StatusCode: 429},
 				Message:  "API rate limit exceeded",
 			},
-			resource: "test resource",
+			resourceType: ResourceTypeLabel,
 			want:     &RateLimitError{},
 			wantMsg:  "rate limit exceeded",
 		},
@@ -94,9 +94,9 @@ func TestWrapGitHubError(t *testing.T) {
 					{Code: "already_exists"},
 				},
 			},
-			resource: "label \"bug\" on \"owner/repo\"",
-			want:     &AlreadyExistsError{Resource: "label \"bug\" on \"owner/repo\""},
-			wantMsg:  "label \"bug\" on \"owner/repo\" already exists",
+			resourceType: ResourceTypeLabel,
+			want:         &AlreadyExistsError{ResourceType: ResourceTypeLabel},
+			wantMsg:      "label already exists",
 		},
 		{
 			name: "422 other validation error",
@@ -107,7 +107,7 @@ func TestWrapGitHubError(t *testing.T) {
 					{Code: "invalid"},
 				},
 			},
-			resource: "test resource",
+			resourceType: ResourceTypeLabel,
 			want:     fmt.Errorf("GitHub API error (status 422): Validation Failed"),
 			wantMsg:  "GitHub API error (status 422): Validation Failed",
 		},
@@ -117,14 +117,14 @@ func TestWrapGitHubError(t *testing.T) {
 				Response: &http.Response{StatusCode: 500},
 				Message:  "Internal Server Error",
 			},
-			resource: "test resource",
+			resourceType: ResourceTypeLabel,
 			want:     fmt.Errorf("GitHub API error (status 500): Internal Server Error"),
 			wantMsg:  "GitHub API error (status 500): Internal Server Error",
 		},
 		{
 			name:     "non-GitHub error",
 			err:      errors.New("network error"),
-			resource: "test resource",
+			resourceType: ResourceTypeLabel,
 			want:     errors.New("network error"),
 			wantMsg:  "network error",
 		},
@@ -132,7 +132,7 @@ func TestWrapGitHubError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := wrapGitHubError(tt.err, tt.resource)
+			got := wrapGitHubError(tt.err, tt.resourceType)
 
 			// Check if error is nil
 			if tt.want == nil {
@@ -161,8 +161,8 @@ func TestWrapGitHubError(t *testing.T) {
 				gotErr, ok := got.(*NotFoundError)
 				if !ok {
 					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
-				} else if gotErr.Resource != want.Resource {
-					t.Errorf("NotFoundError.Resource = %v, want %v", gotErr.Resource, want.Resource)
+				} else if gotErr.ResourceType != want.ResourceType {
+					t.Errorf("NotFoundError.ResourceType = %v, want %v", gotErr.ResourceType, want.ResourceType)
 				}
 			case *RateLimitError:
 				if _, ok := got.(*RateLimitError); !ok {
@@ -172,8 +172,8 @@ func TestWrapGitHubError(t *testing.T) {
 				gotErr, ok := got.(*AlreadyExistsError)
 				if !ok {
 					t.Errorf("wrapGitHubError() = %T, want %T", got, want)
-				} else if gotErr.Resource != want.Resource {
-					t.Errorf("AlreadyExistsError.resource = %v, want %v", gotErr.Resource, want.Resource)
+				} else if gotErr.ResourceType != want.ResourceType {
+					t.Errorf("AlreadyExistsError.ResourceType = %v, want %v", gotErr.ResourceType, want.ResourceType)
 				}
 			}
 		})
@@ -189,7 +189,7 @@ func TestHelperFunctions(t *testing.T) {
 	}{
 		{
 			name:     "IsNotFound with NotFoundError",
-			err:      &NotFoundError{Resource: "test"},
+			err:      &NotFoundError{ResourceType: ResourceTypeLabel},
 			checkFn:  IsNotFound,
 			expected: true,
 		},
@@ -231,19 +231,19 @@ func TestHelperFunctions(t *testing.T) {
 		},
 		{
 			name:     "IsRateLimit with other error",
-			err:      &AlreadyExistsError{Resource: "test"},
+			err:      &AlreadyExistsError{ResourceType: ResourceTypeLabel},
 			checkFn:  IsRateLimit,
 			expected: false,
 		},
 		{
 			name:     "IsAlreadyExists with AlreadyExistsError",
-			err:      &AlreadyExistsError{Resource: "test"},
+			err:      &AlreadyExistsError{ResourceType: ResourceTypeLabel},
 			checkFn:  IsAlreadyExists,
 			expected: true,
 		},
 		{
 			name:     "IsAlreadyExists with other error",
-			err:      &NotFoundError{Resource: "test"},
+			err:      &NotFoundError{ResourceType: ResourceTypeLabel},
 			checkFn:  IsAlreadyExists,
 			expected: false,
 		},
@@ -275,13 +275,18 @@ func TestErrorMessages(t *testing.T) {
 			wantMsg: "forbidden",
 		},
 		{
-			name:    "NotFoundError with resource",
-			err:     &NotFoundError{Resource: "label \"bug\" on \"owner/repo\""},
-			wantMsg: "label \"bug\" on \"owner/repo\" not found",
+			name:    "NotFoundError with resource type repository",
+			err:     &NotFoundError{ResourceType: ResourceTypeRepository},
+			wantMsg: "repository not found",
 		},
 		{
-			name:    "NotFoundError without resource",
-			err:     &NotFoundError{Resource: ""},
+			name:    "NotFoundError with resource type label",
+			err:     &NotFoundError{ResourceType: ResourceTypeLabel},
+			wantMsg: "label not found",
+		},
+		{
+			name:    "NotFoundError without resource type",
+			err:     &NotFoundError{ResourceType: ""},
 			wantMsg: "not found",
 		},
 		{
@@ -290,13 +295,13 @@ func TestErrorMessages(t *testing.T) {
 			wantMsg: "rate limit exceeded",
 		},
 		{
-			name:    "AlreadyExistsError with resource",
-			err:     &AlreadyExistsError{Resource: "label \"bug\" on \"owner/repo\""},
-			wantMsg: "label \"bug\" on \"owner/repo\" already exists",
+			name:    "AlreadyExistsError with resource type label",
+			err:     &AlreadyExistsError{ResourceType: ResourceTypeLabel},
+			wantMsg: "label already exists",
 		},
 		{
-			name:    "AlreadyExistsError without resource",
-			err:     &AlreadyExistsError{Resource: ""},
+			name:    "AlreadyExistsError without resource type",
+			err:     &AlreadyExistsError{ResourceType: ""},
 			wantMsg: "already exists",
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,8 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "gh-fuda",
 	Short: "gh extension for manipulating labels across multiple repositories",
+	SilenceErrors:      true,
+	SilenceUsage:       true,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/executor/execution_result.go
+++ b/executor/execution_result.go
@@ -87,7 +87,7 @@ func (er *ExecutionResult) Summary() string {
 		return "Summary: all operations completed successfully"
 	}
 
-	return fmt.Sprintf("Summary: some operations failed: %d repositories succeeded, %d failed", 
+	return fmt.Sprintf("Summary: %d repositories succeeded, %d failed", 
 		successCount, failCount)
 }
 

--- a/executor/execution_result.go
+++ b/executor/execution_result.go
@@ -1,0 +1,101 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package executor
+
+import (
+	"fmt"
+
+	"github.com/tnagatomi/gh-fuda/api"
+)
+
+// RepoResult represents the result of operations on a repository
+type RepoResult struct {
+	Repo   string
+	Errors []error
+}
+
+// ExecutionResult collects and reports the results of execution
+type ExecutionResult struct {
+	results map[string]*RepoResult
+}
+
+// NewExecutionResult creates a new ExecutionResult
+func NewExecutionResult() *ExecutionResult {
+	return &ExecutionResult{
+		results: make(map[string]*RepoResult),
+	}
+}
+
+// AddRepoResult adds a repository result to the execution result
+func (er *ExecutionResult) AddRepoResult(result *RepoResult) {
+	er.results[result.Repo] = result
+}
+
+// RepoResult returns the result for a specific repository, or nil if not found
+func (er *ExecutionResult) RepoResult(repoName string) *RepoResult {
+	return er.results[repoName]
+}
+
+// HasErrors returns true if there are any errors
+func (er *ExecutionResult) HasErrors() bool {
+	for _, result := range er.results {
+		if len(result.Errors) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// IsNotFoundError checks if the error is a 404 Not Found error
+func (er *ExecutionResult) IsNotFoundError(err error) bool {
+	return api.IsNotFound(err)
+}
+
+// Summary returns a summary message
+func (er *ExecutionResult) Summary() string {
+	successCount := 0
+	failCount := 0
+
+	for _, result := range er.results {
+		if len(result.Errors) > 0 {
+			failCount++
+		} else {
+			successCount++
+		}
+	}
+
+	if failCount == 0 {
+		return "Summary: all operations completed successfully"
+	}
+
+	return fmt.Sprintf("Summary: some operations failed: %d repositories succeeded, %d failed", 
+		successCount, failCount)
+}
+
+// Err returns an error if any operations failed
+func (er *ExecutionResult) Err() error {
+	if !er.HasErrors() {
+		return nil
+	}
+	// Return a simple error for exit code purposes
+	return fmt.Errorf("some operations failed")
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -98,11 +98,11 @@ Summary: all operations completed successfully
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
-					return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					return &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 				},
 			},
-			wantOut: `Failed to create label "bug" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
-Failed to create label "enhancement" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+			wantOut: `Failed to create label "bug" for repository "tnagatomi/non-existent-repo": repository not found
+Failed to create label "enhancement" for repository "tnagatomi/non-existent-repo": repository not found
 
 Summary: some operations failed: 0 repositories succeeded, 1 failed
 `,
@@ -149,13 +149,13 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
 					if repo.Repo == "repo-2" {
-						return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+						return &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 					}
 					return nil
 				},
 			},
 			wantOut: `Created label "bug" for repository "tnagatomi/repo-1"
-Failed to create label "bug" for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Failed to create label "bug" for repository "tnagatomi/repo-2": repository not found
 Created label "bug" for repository "tnagatomi/repo-3"
 
 Summary: some operations failed: 2 repositories succeeded, 1 failed
@@ -310,11 +310,11 @@ Summary: all operations completed successfully
 			},
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
-					return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					return &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 				},
 			},
-			wantOut: `Failed to delete label "bug" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
-Failed to delete label "enhancement" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+			wantOut: `Failed to delete label "bug" for repository "tnagatomi/non-existent-repo": repository not found
+Failed to delete label "enhancement" for repository "tnagatomi/non-existent-repo": repository not found
 
 Summary: some operations failed: 0 repositories succeeded, 1 failed
 `,
@@ -361,13 +361,13 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
 					if repo.Repo == "repo-2" {
-						return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+						return &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 					}
 					return nil
 				},
 			},
 			wantOut: `Deleted label "bug" for repository "tnagatomi/repo-1"
-Failed to delete label "bug" for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Failed to delete label "bug" for repository "tnagatomi/repo-2": repository not found
 Deleted label "bug" for repository "tnagatomi/repo-3"
 
 Summary: some operations failed: 2 repositories succeeded, 1 failed
@@ -529,7 +529,7 @@ Summary: all operations completed successfully
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
 					if repo.Repo == "non-existent-repo" {
-						return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+						return nil, &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 					}
 					return []string{}, nil
 				},
@@ -539,7 +539,7 @@ Summary: all operations completed successfully
 			},
 			wantOut: `Created label "bug" for repository "tnagatomi/mock-repo-1"
 Created label "enhancement" for repository "tnagatomi/mock-repo-1"
-Failed to list labels for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+Failed to list labels for repository "tnagatomi/non-existent-repo": repository not found
 
 Summary: some operations failed: 1 repositories succeeded, 1 failed
 `,
@@ -615,7 +615,7 @@ Summary: some operations failed: 0 repositories succeeded, 2 failed
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
 					if repo.Repo == "repo-2" {
-						return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+						return nil, &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 					}
 					return []string{"old-label"}, nil
 				},
@@ -631,7 +631,7 @@ Summary: some operations failed: 0 repositories succeeded, 2 failed
 			},
 			wantOut: `Deleted label "old-label" for repository "tnagatomi/repo-1"
 Created label "bug" for repository "tnagatomi/repo-1"
-Failed to list labels for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Failed to list labels for repository "tnagatomi/repo-2": repository not found
 Failed to delete label "old-label" for repository "tnagatomi/repo-3": forbidden
 Created label "bug" for repository "tnagatomi/repo-3"
 
@@ -861,10 +861,10 @@ Summary: all operations completed successfully
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
-					return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					return nil, &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 				},
 			},
-			wantOut: `Failed to list labels for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+			wantOut: `Failed to list labels for repository "tnagatomi/non-existent-repo": repository not found
 
 Summary: some operations failed: 0 repositories succeeded, 1 failed
 `,
@@ -917,7 +917,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
 					if repo.Repo == "repo-2" {
-						return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+						return nil, &api.NotFoundError{ResourceType: api.ResourceTypeRepository}
 					}
 					return []string{"bug"}, nil
 				},
@@ -926,7 +926,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 				},
 			},
 			wantOut: `Deleted label "bug" for repository "tnagatomi/repo-1"
-Failed to list labels for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Failed to list labels for repository "tnagatomi/repo-2": repository not found
 Deleted label "bug" for repository "tnagatomi/repo-3"
 
 Summary: some operations failed: 2 repositories succeeded, 1 failed

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -104,7 +104,7 @@ Summary: all operations completed successfully
 			wantOut: `Failed to create label "bug" for repository "tnagatomi/non-existent-repo": repository not found
 Failed to create label "enhancement" for repository "tnagatomi/non-existent-repo": repository not found
 
-Summary: some operations failed: 0 repositories succeeded, 1 failed
+Summary: 0 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantCall: []struct {
@@ -129,7 +129,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 			},
 			wantOut: `Failed to create label "bug" for repository "tnagatomi/private-repo": forbidden
 
-Summary: some operations failed: 0 repositories succeeded, 1 failed
+Summary: 0 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantCall: []struct {
@@ -158,7 +158,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 Failed to create label "bug" for repository "tnagatomi/repo-2": repository not found
 Created label "bug" for repository "tnagatomi/repo-3"
 
-Summary: some operations failed: 2 repositories succeeded, 1 failed
+Summary: 2 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantCall: []struct {
@@ -316,7 +316,7 @@ Summary: all operations completed successfully
 			wantOut: `Failed to delete label "bug" for repository "tnagatomi/non-existent-repo": repository not found
 Failed to delete label "enhancement" for repository "tnagatomi/non-existent-repo": repository not found
 
-Summary: some operations failed: 0 repositories succeeded, 1 failed
+Summary: 0 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantCall: []struct {
@@ -341,7 +341,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 			},
 			wantOut: `Failed to delete label "bug" for repository "tnagatomi/private-repo": forbidden
 
-Summary: some operations failed: 0 repositories succeeded, 1 failed
+Summary: 0 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantCall: []struct {
@@ -370,7 +370,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 Failed to delete label "bug" for repository "tnagatomi/repo-2": repository not found
 Deleted label "bug" for repository "tnagatomi/repo-3"
 
-Summary: some operations failed: 2 repositories succeeded, 1 failed
+Summary: 2 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantCall: []struct {
@@ -541,7 +541,7 @@ Summary: all operations completed successfully
 Created label "enhancement" for repository "tnagatomi/mock-repo-1"
 Failed to list labels for repository "tnagatomi/non-existent-repo": repository not found
 
-Summary: some operations failed: 1 repositories succeeded, 1 failed
+Summary: 1 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantListCall: []option.Repo{
@@ -582,7 +582,7 @@ Summary: some operations failed: 1 repositories succeeded, 1 failed
 			wantOut: `Failed to update label "bug" for repository "tnagatomi/private-repo-1": forbidden
 Failed to update label "bug" for repository "tnagatomi/private-repo-2": forbidden
 
-Summary: some operations failed: 0 repositories succeeded, 2 failed
+Summary: 0 repositories succeeded, 2 failed
 `,
 			wantErr: true,
 			wantListCall: []option.Repo{
@@ -635,7 +635,7 @@ Failed to list labels for repository "tnagatomi/repo-2": repository not found
 Failed to delete label "old-label" for repository "tnagatomi/repo-3": forbidden
 Created label "bug" for repository "tnagatomi/repo-3"
 
-Summary: some operations failed: 1 repositories succeeded, 2 failed
+Summary: 1 repositories succeeded, 2 failed
 `,
 			wantErr: true,
 			wantListCall: []option.Repo{
@@ -866,7 +866,7 @@ Summary: all operations completed successfully
 			},
 			wantOut: `Failed to list labels for repository "tnagatomi/non-existent-repo": repository not found
 
-Summary: some operations failed: 0 repositories succeeded, 1 failed
+Summary: 0 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantListCall: []option.Repo{
@@ -894,7 +894,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 			wantOut: `Failed to delete label "bug" for repository "tnagatomi/private-repo": forbidden
 Failed to delete label "enhancement" for repository "tnagatomi/private-repo": forbidden
 
-Summary: some operations failed: 0 repositories succeeded, 1 failed
+Summary: 0 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantListCall: []option.Repo{
@@ -929,7 +929,7 @@ Summary: some operations failed: 0 repositories succeeded, 1 failed
 Failed to list labels for repository "tnagatomi/repo-2": repository not found
 Deleted label "bug" for repository "tnagatomi/repo-3"
 
-Summary: some operations failed: 2 repositories succeeded, 1 failed
+Summary: 2 repositories succeeded, 1 failed
 `,
 			wantErr: true,
 			wantListCall: []option.Repo{

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/tnagatomi/gh-fuda/api"
 	"github.com/tnagatomi/gh-fuda/internal/mock"
 	"github.com/tnagatomi/gh-fuda/option"
 )
@@ -41,6 +42,8 @@ func TestCreate(t *testing.T) {
 			wantOut: `Created label "bug" for repository "tnagatomi/mock-repo"
 Created label "enhancement" for repository "tnagatomi/mock-repo"
 Created label "question" for repository "tnagatomi/mock-repo"
+
+Summary: all operations completed successfully
 `,
 			wantErr: false,
 			wantCall: []struct {
@@ -70,6 +73,8 @@ Created label "question" for repository "tnagatomi/mock-repo-1"
 Created label "bug" for repository "tnagatomi/mock-repo-2"
 Created label "enhancement" for repository "tnagatomi/mock-repo-2"
 Created label "question" for repository "tnagatomi/mock-repo-2"
+
+Summary: all operations completed successfully
 `,
 			wantErr: false,
 			wantCall: []struct {
@@ -82,6 +87,87 @@ Created label "question" for repository "tnagatomi/mock-repo-2"
 				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
 				{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
 				{Label: option.Label{Name: "question", Description: "This is a question", Color: "0000ff"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
+			},
+		},
+		{
+			name:   "repository not found error",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/non-existent-repo",
+				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
+			},
+			mock: &mock.MockAPI{
+				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
+					return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+				},
+			},
+			wantOut: `Failed to create label "bug" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+Failed to create label "enhancement" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+
+Summary: some operations failed: 0 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "non-existent-repo"}},
+				{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "non-existent-repo"}},
+			},
+		},
+		{
+			name:   "permission error",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/private-repo",
+				labelOption: "bug:ff0000:This is a bug",
+			},
+			mock: &mock.MockAPI{
+				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
+					return &api.ForbiddenError{}
+				},
+			},
+			wantOut: `Failed to create label "bug" for repository "tnagatomi/private-repo": forbidden
+
+Summary: some operations failed: 0 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "private-repo"}},
+			},
+		},
+		{
+			name:   "multiple repositories with partial failure",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
+				labelOption: "bug:ff0000:This is a bug",
+			},
+			mock: &mock.MockAPI{
+				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
+					if repo.Repo == "repo-2" {
+						return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					}
+					return nil
+				},
+			},
+			wantOut: `Created label "bug" for repository "tnagatomi/repo-1"
+Failed to create label "bug" for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Created label "bug" for repository "tnagatomi/repo-3"
+
+Summary: some operations failed: 2 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-1"}},
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-2"}},
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-3"}},
 			},
 		},
 		{
@@ -168,6 +254,8 @@ func TestDelete(t *testing.T) {
 			wantOut: `Deleted label "bug" for repository "tnagatomi/mock-repo"
 Deleted label "enhancement" for repository "tnagatomi/mock-repo"
 Deleted label "question" for repository "tnagatomi/mock-repo"
+
+Summary: all operations completed successfully
 `,
 			wantErr: false,
 			wantCall: []struct {
@@ -197,6 +285,8 @@ Deleted label "question" for repository "tnagatomi/mock-repo-1"
 Deleted label "bug" for repository "tnagatomi/mock-repo-2"
 Deleted label "enhancement" for repository "tnagatomi/mock-repo-2"
 Deleted label "question" for repository "tnagatomi/mock-repo-2"
+
+Summary: all operations completed successfully
 `,
 			wantErr: false,
 			wantCall: []struct {
@@ -209,6 +299,87 @@ Deleted label "question" for repository "tnagatomi/mock-repo-2"
 				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
 				{Label: "enhancement", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
 				{Label: "question", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
+			},
+		},
+		{
+			name:   "repository not found error",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/non-existent-repo",
+				labelOption: "bug,enhancement",
+			},
+			mock: &mock.MockAPI{
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+				},
+			},
+			wantOut: `Failed to delete label "bug" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+Failed to delete label "enhancement" for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+
+Summary: some operations failed: 0 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "non-existent-repo"}},
+				{Label: "enhancement", Repo: option.Repo{Owner: "tnagatomi", Repo: "non-existent-repo"}},
+			},
+		},
+		{
+			name:   "permission error",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/private-repo",
+				labelOption: "bug",
+			},
+			mock: &mock.MockAPI{
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					return &api.ForbiddenError{}
+				},
+			},
+			wantOut: `Failed to delete label "bug" for repository "tnagatomi/private-repo": forbidden
+
+Summary: some operations failed: 0 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "private-repo"}},
+			},
+		},
+		{
+			name:   "multiple repositories with partial failure",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
+				labelOption: "bug",
+			},
+			mock: &mock.MockAPI{
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					if repo.Repo == "repo-2" {
+						return &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					}
+					return nil
+				},
+			},
+			wantOut: `Deleted label "bug" for repository "tnagatomi/repo-1"
+Failed to delete label "bug" for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Deleted label "bug" for repository "tnagatomi/repo-3"
+
+Summary: some operations failed: 2 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-1"}},
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-2"}},
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-3"}},
 			},
 		},
 		{
@@ -279,57 +450,221 @@ func TestSync(t *testing.T) {
 			Label option.Label
 			Repo  option.Repo
 		}
+		wantUpdateCall []struct {
+			Label option.Label
+			Repo  option.Repo
+		}
 		wantDeleteCall []struct {
 			Label string
 			Repo  option.Repo
 		}
 	}{
 		{
-			name:   "single repository",
+			name:   "multiple repositories with different existing labels",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo",
+				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/mock-repo-2",
 				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
-					return []string{"bug", "enhancement", "question"}, nil
+					if repo.Repo == "mock-repo-1" {
+						return []string{"bug", "enhancement", "question"}, nil
+					}
+					return []string{"bug", "help wanted"}, nil
+				},
+				UpdateLabelFunc: func(label option.Label, repo option.Repo) error {
+					return nil
+				},
+				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
+					return nil
 				},
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
 					return nil
 				},
 			},
-			wantOut: `Emptying labels first
-Deleted label "bug" for repository "tnagatomi/mock-repo"
-Deleted label "enhancement" for repository "tnagatomi/mock-repo"
-Deleted label "question" for repository "tnagatomi/mock-repo"
-Creating labels
-Created label "bug" for repository "tnagatomi/mock-repo"
-Created label "enhancement" for repository "tnagatomi/mock-repo"
+			wantOut: `Deleted label "question" for repository "tnagatomi/mock-repo-1"
+Updated label "bug" for repository "tnagatomi/mock-repo-1"
+Updated label "enhancement" for repository "tnagatomi/mock-repo-1"
+Deleted label "help wanted" for repository "tnagatomi/mock-repo-2"
+Updated label "bug" for repository "tnagatomi/mock-repo-2"
+Created label "enhancement" for repository "tnagatomi/mock-repo-2"
+
+Summary: all operations completed successfully
 `,
 			wantErr: false,
 			wantListCall: []option.Repo{
-				{Owner: "tnagatomi", Repo: "mock-repo"},
+				{Owner: "tnagatomi", Repo: "mock-repo-1"},
+				{Owner: "tnagatomi", Repo: "mock-repo-2"},
 			},
 			wantCreateCall: []struct {
 				Label option.Label
 				Repo  option.Repo
 			}{
-				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo"}},
-				{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo"}},
+				{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
+			},
+			wantUpdateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
+				{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
 			},
 			wantDeleteCall: []struct {
 				Label string
 				Repo  option.Repo
 			}{
-				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo"}},
-				{Label: "enhancement", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo"}},
-				{Label: "question", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo"}},
+				{Label: "question", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
+				{Label: "help wanted", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
 			},
 		},
 		{
-			name:   "multiple repository",
+			name:   "repository not found on list labels",
 			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/non-existent-repo",
+				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
+					if repo.Repo == "non-existent-repo" {
+						return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					}
+					return []string{}, nil
+				},
+				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
+					return nil
+				},
+			},
+			wantOut: `Created label "bug" for repository "tnagatomi/mock-repo-1"
+Created label "enhancement" for repository "tnagatomi/mock-repo-1"
+Failed to list labels for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+
+Summary: some operations failed: 1 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "mock-repo-1"},
+				{Owner: "tnagatomi", Repo: "non-existent-repo"},
+			},
+			wantCreateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
+				{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
+			},
+			wantUpdateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{},
+		},
+		{
+			name:   "permission error on update",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/private-repo-1,tnagatomi/private-repo-2",
+				labelOption: "bug:ff0000:This is a bug",
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
+					return []string{"bug"}, nil
+				},
+				UpdateLabelFunc: func(label option.Label, repo option.Repo) error {
+					return &api.ForbiddenError{}
+				},
+			},
+			wantOut: `Failed to update label "bug" for repository "tnagatomi/private-repo-1": forbidden
+Failed to update label "bug" for repository "tnagatomi/private-repo-2": forbidden
+
+Summary: some operations failed: 0 repositories succeeded, 2 failed
+`,
+			wantErr: true,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "private-repo-1"},
+				{Owner: "tnagatomi", Repo: "private-repo-2"},
+			},
+			wantCreateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{},
+			wantUpdateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "private-repo-1"}},
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "private-repo-2"}},
+			},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{},
+		},
+		{
+			name:   "mixed errors during sync",
+			dryrun: false,
+			args: args{
+				repoOption:  "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
+				labelOption: "bug:ff0000:This is a bug",
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
+					if repo.Repo == "repo-2" {
+						return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					}
+					return []string{"old-label"}, nil
+				},
+				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
+					return nil
+				},
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					if repo.Repo == "repo-3" {
+						return &api.ForbiddenError{}
+					}
+					return nil
+				},
+			},
+			wantOut: `Deleted label "old-label" for repository "tnagatomi/repo-1"
+Created label "bug" for repository "tnagatomi/repo-1"
+Failed to list labels for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Failed to delete label "old-label" for repository "tnagatomi/repo-3": forbidden
+Created label "bug" for repository "tnagatomi/repo-3"
+
+Summary: some operations failed: 1 repositories succeeded, 2 failed
+`,
+			wantErr: true,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "repo-1"},
+				{Owner: "tnagatomi", Repo: "repo-2"},
+				{Owner: "tnagatomi", Repo: "repo-3"},
+			},
+			wantCreateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-1"}},
+				{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-3"}},
+			},
+			wantUpdateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{
+				{Label: "old-label", Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-1"}},
+				{Label: "old-label", Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-3"}},
+			},
+		},
+		{
+			name:   "dry-run",
+			dryrun: true,
 			args: args{
 				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/mock-repo-2",
 				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
@@ -339,80 +674,31 @@ Created label "enhancement" for repository "tnagatomi/mock-repo"
 					return nil
 				},
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
-					if repo.Owner == "tnagatomi" && repo.Repo == "mock-repo-1" {
+					if repo.Repo == "mock-repo-1" {
 						return []string{"bug", "enhancement", "question"}, nil
-					} else if repo.Owner == "tnagatomi" && repo.Repo == "mock-repo-2" {
-						return []string{"bug"}, nil
 					}
-					return nil, fmt.Errorf("unexpected repository: %v", repo)
+					return []string{}, nil
 				},
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
 					return nil
 				},
 			},
-			wantOut: `Emptying labels first
-Deleted label "bug" for repository "tnagatomi/mock-repo-1"
-Deleted label "enhancement" for repository "tnagatomi/mock-repo-1"
-Deleted label "question" for repository "tnagatomi/mock-repo-1"
-Deleted label "bug" for repository "tnagatomi/mock-repo-2"
-Creating labels
-Created label "bug" for repository "tnagatomi/mock-repo-1"
-Created label "enhancement" for repository "tnagatomi/mock-repo-1"
-Created label "bug" for repository "tnagatomi/mock-repo-2"
-Created label "enhancement" for repository "tnagatomi/mock-repo-2"
+			wantOut: `Would delete label "question" for repository "tnagatomi/mock-repo-1"
+Would update label "bug" for repository "tnagatomi/mock-repo-1"
+Would update label "enhancement" for repository "tnagatomi/mock-repo-1"
+Would create label "bug" for repository "tnagatomi/mock-repo-2"
+Would create label "enhancement" for repository "tnagatomi/mock-repo-2"
 `,
 			wantErr: false,
 			wantListCall: []option.Repo{
 				{Owner: "tnagatomi", Repo: "mock-repo-1"},
 				{Owner: "tnagatomi", Repo: "mock-repo-2"},
 			},
-		wantCreateCall: []struct {
-			Label option.Label
-			Repo  option.Repo
-		}{
-			{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
-			{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
-			{Label: option.Label{Name: "bug", Description: "This is a bug", Color: "ff0000"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
-			{Label: option.Label{Name: "enhancement", Description: "This is an enhancement", Color: "00ff00"}, Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
-		},
-		wantDeleteCall: []struct {
-			Label string
-			Repo  option.Repo
-		}{
-			{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
-			{Label: "enhancement", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
-			{Label: "question", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
-			{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
-		}},
-		{
-			name:   "dry-run",
-			dryrun: true,
-			args: args{
-				repoOption:  "tnagatomi/mock-repo",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
-			},
-			mock: &mock.MockAPI{
-				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
-					return nil
-				},
-				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
-					return []string{"bug", "enhancement", "question"}, nil
-				},
-				DeleteLabelFunc: func(label string, repo option.Repo) error {
-					return nil
-				},
-			},
-			wantOut: `Would delete label "bug" for repository "tnagatomi/mock-repo"
-Would delete label "enhancement" for repository "tnagatomi/mock-repo"
-Would delete label "question" for repository "tnagatomi/mock-repo"
-Would create label "bug" for repository "tnagatomi/mock-repo"
-Would create label "enhancement" for repository "tnagatomi/mock-repo"
-`,
-			wantErr: false,
-			wantListCall: []option.Repo{
-				{Owner: "tnagatomi", Repo: "mock-repo"},
-			},
 			wantCreateCall: []struct {
+				Label option.Label
+				Repo  option.Repo
+			}{},
+			wantUpdateCall: []struct {
 				Label option.Label
 				Repo  option.Repo
 			}{},
@@ -462,6 +748,14 @@ Would create label "enhancement" for repository "tnagatomi/mock-repo"
 					t.Errorf("Sync() wantDeleteCall = %v, got %v", tt.wantDeleteCall, tt.mock.DeleteLabelCalls)
 				}
 			}
+			if len(tt.wantUpdateCall) != len(tt.mock.UpdateLabelCalls) {
+				t.Errorf("Sync() wantUpdateCall = %v, got %v", tt.wantUpdateCall, tt.mock.UpdateLabelCalls)
+			}
+			for i, call := range tt.mock.UpdateLabelCalls {
+				if call.Label != tt.wantUpdateCall[i].Label || call.Repo != tt.wantUpdateCall[i].Repo {
+					t.Errorf("Sync() wantUpdateCall = %v, got %v", tt.wantUpdateCall, tt.mock.UpdateLabelCalls)
+				}
+			}
 		})
 	}
 }
@@ -500,6 +794,8 @@ func TestEmpty(t *testing.T) {
 			wantOut: `Deleted label "bug" for repository "tnagatomi/mock-repo"
 Deleted label "enhancement" for repository "tnagatomi/mock-repo"
 Deleted label "question" for repository "tnagatomi/mock-repo"
+
+Summary: all operations completed successfully
 `,
 			wantErr: false,
 			wantListCall: []option.Repo{
@@ -538,6 +834,8 @@ Deleted label "enhancement" for repository "tnagatomi/mock-repo-1"
 Deleted label "question" for repository "tnagatomi/mock-repo-1"
 Deleted label "invalid" for repository "tnagatomi/mock-repo-2"
 Deleted label "help wanted" for repository "tnagatomi/mock-repo-2"
+
+Summary: all operations completed successfully
 `,
 			wantErr: false,
 			wantListCall: []option.Repo{
@@ -553,6 +851,98 @@ Deleted label "help wanted" for repository "tnagatomi/mock-repo-2"
 				{Label: "question", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-1"}},
 				{Label: "invalid", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
 				{Label: "help wanted", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo-2"}},
+			},
+		},
+		{
+			name:   "repository not found on list",
+			dryrun: false,
+			args: args{
+				repoOption: "tnagatomi/non-existent-repo",
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
+					return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+				},
+			},
+			wantOut: `Failed to list labels for repository "tnagatomi/non-existent-repo": repository "tnagatomi/non-existent-repo" not found
+
+Summary: some operations failed: 0 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "non-existent-repo"},
+			},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{},
+		},
+		{
+			name:   "permission error on delete",
+			dryrun: false,
+			args: args{
+				repoOption: "tnagatomi/private-repo",
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
+					return []string{"bug", "enhancement"}, nil
+				},
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					return &api.ForbiddenError{}
+				},
+			},
+			wantOut: `Failed to delete label "bug" for repository "tnagatomi/private-repo": forbidden
+Failed to delete label "enhancement" for repository "tnagatomi/private-repo": forbidden
+
+Summary: some operations failed: 0 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "private-repo"},
+			},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "private-repo"}},
+				{Label: "enhancement", Repo: option.Repo{Owner: "tnagatomi", Repo: "private-repo"}},
+			},
+		},
+		{
+			name:   "multiple repositories with partial failure",
+			dryrun: false,
+			args: args{
+				repoOption: "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
+					if repo.Repo == "repo-2" {
+						return nil, &api.NotFoundError{Resource: fmt.Sprintf("repository %q", repo.String())}
+					}
+					return []string{"bug"}, nil
+				},
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					return nil
+				},
+			},
+			wantOut: `Deleted label "bug" for repository "tnagatomi/repo-1"
+Failed to list labels for repository "tnagatomi/repo-2": repository "tnagatomi/repo-2" not found
+Deleted label "bug" for repository "tnagatomi/repo-3"
+
+Summary: some operations failed: 2 repositories succeeded, 1 failed
+`,
+			wantErr: true,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "repo-1"},
+				{Owner: "tnagatomi", Repo: "repo-2"},
+				{Owner: "tnagatomi", Repo: "repo-3"},
+			},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-1"}},
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "repo-3"}},
 			},
 		},
 		{

--- a/internal/mock/api.go
+++ b/internal/mock/api.go
@@ -9,6 +9,12 @@ type MockAPI struct {
 		Repo  option.Repo
 	}
 
+	UpdateLabelFunc func(label option.Label, repo option.Repo) error
+	UpdateLabelCalls []struct {
+		Label option.Label
+		Repo  option.Repo
+	}
+
 	DeleteLabelFunc func(label string, repo option.Repo) error
 	DeleteLabelCalls []struct {
 		Label string
@@ -29,6 +35,19 @@ func (m *MockAPI) CreateLabel(label option.Label, repo option.Repo) error {
 
 	if m.CreateLabelFunc != nil {
 		return m.CreateLabelFunc(label, repo)
+	}
+
+	return nil
+}
+
+func (m *MockAPI) UpdateLabel(label option.Label, repo option.Repo) error {
+	m.UpdateLabelCalls = append(m.UpdateLabelCalls, struct {
+		Label option.Label
+		Repo  option.Repo
+	}{label,repo})
+
+	if m.UpdateLabelFunc != nil {
+		return m.UpdateLabelFunc(label, repo)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Simplify error messages by removing redundant information
- Eliminate duplicate "some operations failed" messages
- Prevent usage display for runtime errors

Fixes https://github.com/tnagatomi/gh-fuda/issues/10

## Changes

### 1. Simplified Error Messages
- Introduced `ResourceType` enum to categorize errors (repository vs label)
- Changed error format from `repository "owner/repo" not found` to `repository not found`
- Maintains ability to distinguish between different error types while reducing verbosity

### 2. Removed Message Duplication
- Changed Summary format from `Summary: some operations failed: X repositories succeeded, Y failed` to `Summary: X repositories succeeded, Y failed`
- Eliminates redundancy when both summary and error are displayed

### 3. Suppress Usage on Runtime Errors
- Set `SilenceErrors` and `SilenceUsage` to true in root command
- Usage/help is now only shown for actual command syntax errors, not runtime failures

## Example Output

Before:
```
Failed to list labels for repository "tnagatomi/test-repository-for-takolabel-3": repository "tnagatomi/test-repository-for-takolabel-3" not found

Summary: some operations failed: 2 repositories succeeded, 1 failed
Error: failed to empty labels: some operations failed
Usage:
  gh-fuda empty [flags]
...
```

After:
```
Failed to list labels for repository "tnagatomi/test-repository-for-takolabel-3": repository not found

Summary: 2 repositories succeeded, 1 failed
Error: failed to empty labels: some operations failed
```

## Test plan
- [x] All existing tests pass
- [x] Manually tested error scenarios with non-existent repositories
- [x] Verified usage is not shown for runtime errors
- [x] Confirmed error messages are properly simplified

🤖 Generated with [Claude Code](https://claude.ai/code)