### PR TITLE
Add JSON file support for label operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,38 @@ Create specified labels to the specified repositories.
 ##### Options
 
 - `-l`, `--labels`: Specify the labels to create in the format of `'label1:color1:description1[,label2:color2:description2,...]'` (description can be omitted)
+- `--json`: Specify the path to a JSON file containing labels to create
 
 ##### Example
 
 ```bash
+# Using inline labels
 gh fuda create -R "owner1/repo1,owner1/repo2,owner2/repo1" -l "label1:ff0000:description for label 1,label2:00ff00,label3:0000ff"
+
+# Using JSON file
+gh fuda create -R "owner1/repo1,owner1/repo2,owner2/repo1" --json labels.json
+```
+
+##### JSON File Format
+
+```json
+[
+  {
+    "name": "bug",
+    "color": "d73a4a",
+    "description": "Something isn't working"
+  },
+  {
+    "name": "enhancement",
+    "color": "a2eeef",
+    "description": "New feature or request"
+  },
+  {
+    "name": "documentation",
+    "color": "0075ca",
+    "description": "Improvements or additions to documentation"
+  }
+]
 ```
 
 #### Delete Labels
@@ -68,14 +95,23 @@ Sync the labels in the specified repositories with the specified labels.
 
 ##### Options
 
-- `-l`, `--labels`: Specify the labels to set in the format ofSpecify the labels to set in the format of `'label1:color1:description1[,label2:color2:description2,...]'` (description can be omitted)
+- `-l`, `--labels`: Specify the labels to set in the format of `'label1:color1:description1[,label2:color2:description2,...]'` (description can be omitted)
+- `--json`: Specify the path to a JSON file containing labels to sync
 - `--force`: Do not prompt for confirmation
 
 ##### Example
 
 ```bash
+# Using inline labels
 gh fuda sync -R "owner1/repo1,owner1/repo2,owner2/repo1" -l "label1:ff0000:description for label 1,label2:00ff00,label3:0000ff"
+
+# Using JSON file
+gh fuda sync -R "owner1/repo1,owner1/repo2,owner2/repo1" --json labels.json
 ```
+
+##### JSON File Format
+
+The JSON file format is the same as the one used for the `create` command. See the [Create Labels](#create-labels) section for details.
 
 #### Empty Labels
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gh fuda create -R "owner1/repo1,owner1/repo2,owner2/repo1" --json labels.json
   },
   {
     "name": "documentation",
-    "color": "0075ca",
+    "color": "07c",
     "description": "Improvements or additions to documentation"
   }
 ]

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -22,13 +22,18 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"os"
+
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/spf13/cobra"
 	"github.com/tnagatomi/gh-fuda/executor"
-	"io"
-	"os"
+	"github.com/tnagatomi/gh-fuda/option"
+	"github.com/tnagatomi/gh-fuda/parser"
 )
+
 
 // NewCreateCmd initialize the create command
 func NewCreateCmd(out io.Writer) *cobra.Command {
@@ -36,6 +41,32 @@ func NewCreateCmd(out io.Writer) *cobra.Command {
 		Use:   "create",
 		Short: "Create specified labels to the specified repositories",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if jsonPath != "" && labels != "" {
+				return errors.New("--labels (-l) and --json cannot be used together")
+			}
+			if jsonPath == "" && labels == "" {
+				return errors.New("either --labels (-l) or --json must be specified")
+			}
+
+			var labelList []option.Label
+			var err error
+			if jsonPath != "" {
+				labelList, err = parser.LabelFromJSON(jsonPath)
+				if err != nil {
+					return fmt.Errorf("failed to parse JSON file: %v", err)
+				}
+			} else {
+				labelList, err = parser.Label(labels)
+				if err != nil {
+					return fmt.Errorf("failed to parse labels option: %v", err)
+				}
+			}
+
+			repoList, err := parser.Repo(repos)
+			if err != nil {
+				return fmt.Errorf("failed to parse repos option: %v", err)
+			}
+
 			client, err := api.NewHTTPClient(api.ClientOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create gh http client: %v", err)
@@ -46,7 +77,7 @@ func NewCreateCmd(out io.Writer) *cobra.Command {
 				return fmt.Errorf("failed to create exector: %v", err)
 			}
 
-			err = e.Create(out, repos, labels)
+			err = e.Create(out, repoList, labelList)
 			if err != nil {
 				return fmt.Errorf("failed to create labels: %v", err)
 			}
@@ -62,9 +93,5 @@ func init() {
 	rootCmd.AddCommand(createCmd)
 
 	createCmd.Flags().StringVarP(&labels, "labels", "l", "", "Specify the labels to create in the format of 'label1:color1:description1[,label2:color2:description2,...]' (description can be omitted)")
-
-	err := createCmd.MarkFlagRequired("labels")
-	if err != nil {
-		fmt.Printf("Failed to mark flag required: %v\n", err)
-	}
+	createCmd.Flags().StringVar(&jsonPath, "json", "", "Specify the path to a JSON file containing labels to create")
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -74,7 +74,7 @@ func NewCreateCmd(out io.Writer) *cobra.Command {
 
 			e, err := executor.NewExecutor(client, dryRun)
 			if err != nil {
-				return fmt.Errorf("failed to create exector: %v", err)
+				return fmt.Errorf("failed to create executor: %v", err)
 			}
 
 			err = e.Create(out, repoList, labelList)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -47,7 +47,7 @@ func NewDeleteCmd(in io.Reader, out io.Writer) *cobra.Command {
 
 			e, err := executor.NewExecutor(client, dryRun)
 			if err != nil {
-				return fmt.Errorf("failed to create exector: %v", err)
+				return fmt.Errorf("failed to create executor: %v", err)
 			}
 
 			repoList, err := parser.Repo(repos)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -23,10 +23,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cli/go-gh/v2/pkg/api"
-	"github.com/tnagatomi/gh-fuda/executor"
 	"io"
 	"os"
+	"strings"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/tnagatomi/gh-fuda/executor"
+	"github.com/tnagatomi/gh-fuda/parser"
 
 	"github.com/spf13/cobra"
 )
@@ -47,6 +50,13 @@ func NewDeleteCmd(in io.Reader, out io.Writer) *cobra.Command {
 				return fmt.Errorf("failed to create exector: %v", err)
 			}
 
+			repoList, err := parser.Repo(repos)
+			if err != nil {
+				return fmt.Errorf("failed to parse repos option: %v", err)
+			}
+
+			labelList := strings.Split(labels, ",")
+
 			if !dryRun && !force {
 				confirmed, err := confirm(in, out)
 				if err != nil {
@@ -58,7 +68,7 @@ func NewDeleteCmd(in io.Reader, out io.Writer) *cobra.Command {
 				}
 			}
 
-			err = e.Delete(out, repos, labels)
+			err = e.Delete(out, repoList, labelList)
 			if err != nil {
 				return fmt.Errorf("failed to delete labels: %v", err)
 			}

--- a/cmd/empty.go
+++ b/cmd/empty.go
@@ -23,10 +23,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cli/go-gh/v2/pkg/api"
-	"github.com/tnagatomi/gh-fuda/executor"
 	"io"
 	"os"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/tnagatomi/gh-fuda/executor"
+	"github.com/tnagatomi/gh-fuda/parser"
 
 	"github.com/spf13/cobra"
 )
@@ -47,6 +49,11 @@ func NewEmptyCmd(in io.Reader, out io.Writer) *cobra.Command {
 				return fmt.Errorf("failed to create exector: %v", err)
 			}
 
+			repoList, err := parser.Repo(repos)
+			if err != nil {
+				return fmt.Errorf("failed to parse repos option: %v", err)
+			}
+
 			if !dryRun && !force {
 				confirmed, err := confirm(in, out)
 				if err != nil {
@@ -58,7 +65,7 @@ func NewEmptyCmd(in io.Reader, out io.Writer) *cobra.Command {
 				}
 			}
 
-			err = e.Empty(out, repos)
+			err = e.Empty(out, repoList)
 			if err != nil {
 				return fmt.Errorf("failed to empty labels: %v", err)
 			}

--- a/cmd/empty.go
+++ b/cmd/empty.go
@@ -46,7 +46,7 @@ func NewEmptyCmd(in io.Reader, out io.Writer) *cobra.Command {
 
 			e, err := executor.NewExecutor(client, dryRun)
 			if err != nil {
-				return fmt.Errorf("failed to create exector: %v", err)
+				return fmt.Errorf("failed to create executor: %v", err)
 			}
 
 			repoList, err := parser.Repo(repos)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -31,14 +32,15 @@ var (
 	dryRun bool
 	force  bool
 	labels string
+	jsonPath string
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "gh-fuda",
-	Short: "gh extension for manipulating labels across multiple repositories",
-	SilenceErrors:      true,
-	SilenceUsage:       true,
+	Use:           "gh-fuda",
+	Short:         "gh extension for manipulating labels across multiple repositories",
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -74,7 +74,7 @@ func NewSyncCmd(in io.Reader, out io.Writer) *cobra.Command {
 
 			e, err := executor.NewExecutor(client, dryRun)
 			if err != nil {
-				return fmt.Errorf("failed to create exector: %v", err)
+				return fmt.Errorf("failed to create executor: %v", err)
 			}
 
 			if !dryRun && !force {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,11 +22,15 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"github.com/cli/go-gh/v2/pkg/api"
-	"github.com/tnagatomi/gh-fuda/executor"
 	"io"
 	"os"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/tnagatomi/gh-fuda/executor"
+	"github.com/tnagatomi/gh-fuda/option"
+	"github.com/tnagatomi/gh-fuda/parser"
 
 	"github.com/spf13/cobra"
 )
@@ -37,6 +41,32 @@ func NewSyncCmd(in io.Reader, out io.Writer) *cobra.Command {
 		Use:   "sync",
 		Short: "Sync the labels in the specified repositories with the specified labels",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if jsonPath != "" && labels != "" {
+				return errors.New("--labels (-l) and --json cannot be used together")
+			}
+			if jsonPath == "" && labels == "" {
+				return errors.New("either --labels (-l) or --json must be specified")
+			}
+
+			var labelList []option.Label
+			var err error
+			if jsonPath != "" {
+				labelList, err = parser.LabelFromJSON(jsonPath)
+				if err != nil {
+					return fmt.Errorf("failed to parse JSON file: %v", err)
+				}
+			} else {
+				labelList, err = parser.Label(labels)
+				if err != nil {
+					return fmt.Errorf("failed to parse labels option: %v", err)
+				}
+			}
+
+			repoList, err := parser.Repo(repos)
+			if err != nil {
+				return fmt.Errorf("failed to parse repos option: %v", err)
+			}
+
 			client, err := api.NewHTTPClient(api.ClientOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create gh http client: %v", err)
@@ -58,7 +88,7 @@ func NewSyncCmd(in io.Reader, out io.Writer) *cobra.Command {
 				}
 			}
 
-			err = e.Sync(out, repos, labels)
+			err = e.Sync(out, repoList, labelList)
 			if err != nil {
 				return fmt.Errorf("failed to sync labels: %v", err)
 			}
@@ -74,10 +104,6 @@ func init() {
 	rootCmd.AddCommand(syncCmd)
 
 	syncCmd.Flags().StringVarP(&labels, "labels", "l", "", "Specify the labels to set in the format of 'label1:color1:description1[,label2:color2:description2,...]' (description can be omitted)")
+	syncCmd.Flags().StringVar(&jsonPath, "json", "", "Specify the path to a JSON file containing labels to sync")
 	syncCmd.Flags().BoolVar(&force, "force", false, "Do not prompt for confirmation")
-
-	err := syncCmd.MarkFlagRequired("labels")
-	if err != nil {
-		fmt.Printf("Failed to mark flag required: %v\n", err)
-	}
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -25,11 +25,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/tnagatomi/gh-fuda/api"
 	"github.com/tnagatomi/gh-fuda/option"
-	"github.com/tnagatomi/gh-fuda/parser"
 )
 
 // Executor composites github.Client and has dry-run option
@@ -52,16 +50,7 @@ func NewExecutor(client *http.Client, dryrun bool) (*Executor, error) {
 }
 
 // Create creates labels across multiple repositories
-func (e *Executor) Create(out io.Writer, repoOption string, labelOption string) error {
-	labels, err := parser.Label(labelOption)
-	if err != nil {
-		return fmt.Errorf("failed to parse label option: %v", err)
-	}
-	repos, err := parser.Repo(repoOption)
-	if err != nil {
-		return fmt.Errorf("failed to parse repo option: %v", err)
-	}
-
+func (e *Executor) Create(out io.Writer, repos []option.Repo, labels []option.Label) error {
 	er := NewExecutionResult()
 
 	for _, repo := range repos {
@@ -76,7 +65,7 @@ func (e *Executor) Create(out io.Writer, repoOption string, labelOption string) 
 				continue
 			}
 
-			err = e.api.CreateLabel(label, repo)
+			err := e.api.CreateLabel(label, repo)
 			if err != nil {
 				repoResult.Errors = append(repoResult.Errors, err)
 				_, _ = fmt.Fprintf(out, "Failed to create label %q for repository %q: %v\n", label, repo, err)
@@ -98,14 +87,7 @@ func (e *Executor) Create(out io.Writer, repoOption string, labelOption string) 
 }
 
 // Delete deletes labels across multiple repositories
-func (e *Executor) Delete(out io.Writer, repoOption string, labelOption string) error {
-	labels := strings.Split(labelOption, ",")
-
-	repos, err := parser.Repo(repoOption)
-	if err != nil {
-		return fmt.Errorf("failed to parse repo option: %v", err)
-	}
-
+func (e *Executor) Delete(out io.Writer, repos []option.Repo, labels []string) error {
 	er := NewExecutionResult()
 
 	for _, repo := range repos {
@@ -120,7 +102,7 @@ func (e *Executor) Delete(out io.Writer, repoOption string, labelOption string) 
 				continue
 			}
 
-			err = e.api.DeleteLabel(label, repo)
+			err := e.api.DeleteLabel(label, repo)
 			if err != nil {
 				repoResult.Errors = append(repoResult.Errors, err)
 				_, _ = fmt.Fprintf(out, "Failed to delete label %q for repository %q: %v\n", label, repo, err)
@@ -142,17 +124,7 @@ func (e *Executor) Delete(out io.Writer, repoOption string, labelOption string) 
 }
 
 // Sync sync labels across multiple repositories
-func (e *Executor) Sync(out io.Writer, repoOption string, labelOption string) error {
-	repos, err := parser.Repo(repoOption)
-	if err != nil {
-		return fmt.Errorf("failed to parse repo option: %v", err)
-	}
-
-	labels, err := parser.Label(labelOption)
-	if err != nil {
-		return fmt.Errorf("failed to parse label option: %v", err)
-	}
-
+func (e *Executor) Sync(out io.Writer, repos []option.Repo, labels []option.Label) error {
 	er := NewExecutionResult()
 
 	for _, repo := range repos {
@@ -237,12 +209,7 @@ func (e *Executor) Sync(out io.Writer, repoOption string, labelOption string) er
 }
 
 // Empty empties labels across multiple repositories
-func (e *Executor) Empty(out io.Writer, repoOption string) error {
-	repos, err := parser.Repo(repoOption)
-	if err != nil {
-		return fmt.Errorf("failed to parse repo option: %v", err)
-	}
-
+func (e *Executor) Empty(out io.Writer, repos []option.Repo) error {
 	er := NewExecutionResult()
 
 	results := e.emptyLabels(out, repos)
@@ -279,7 +246,7 @@ func (e *Executor) emptyLabels(out io.Writer, repos []option.Repo) []*RepoResult
 				continue
 			}
 
-			err = e.api.DeleteLabel(label, repo)
+			err := e.api.DeleteLabel(label, repo)
 			if err != nil {
 				repoResult.Errors = append(repoResult.Errors, err)
 				_, _ = fmt.Fprintf(out, "Failed to delete label %q for repository %q: %v\n", label, repo, err)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCreate(t *testing.T) {
 	type args struct {
-		repoOption  string
-		labelOption string
+		repos  []option.Repo
+		labels []option.Label
 	}
 	tests := []struct {
 		name    string
@@ -31,8 +31,14 @@ func TestCreate(t *testing.T) {
 			name:   "single repository",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement,question:0000ff:This is a question",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+					{Name: "enhancement", Color: "00ff00", Description: "This is an enhancement"},
+					{Name: "question", Color: "0000ff", Description: "This is a question"},
+				},
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
@@ -59,8 +65,15 @@ Summary: all operations completed successfully
 			name:   "multiple repository", 
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/mock-repo-2",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement,question:0000ff:This is a question",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo-1"},
+					{Owner: "tnagatomi", Repo: "mock-repo-2"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+					{Name: "enhancement", Color: "00ff00", Description: "This is an enhancement"},
+					{Name: "question", Color: "0000ff", Description: "This is a question"},
+				},
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
@@ -93,8 +106,13 @@ Summary: all operations completed successfully
 			name:   "repository not found error",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/non-existent-repo",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "non-existent-repo"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+					{Name: "enhancement", Color: "00ff00", Description: "This is an enhancement"},
+				},
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
@@ -119,8 +137,12 @@ Summary: 0 repositories succeeded, 1 failed
 			name:   "permission error",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/private-repo",
-				labelOption: "bug:ff0000:This is a bug",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "private-repo"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+				},
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
@@ -143,8 +165,14 @@ Summary: 0 repositories succeeded, 1 failed
 			name:   "multiple repositories with partial failure",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
-				labelOption: "bug:ff0000:This is a bug",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "repo-1"},
+					{Owner: "tnagatomi", Repo: "repo-2"},
+					{Owner: "tnagatomi", Repo: "repo-3"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+				},
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
@@ -174,8 +202,14 @@ Summary: 2 repositories succeeded, 1 failed
 			name:   "dry-run",
 			dryrun: true,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement,question:0000ff:This is a question",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+					{Name: "enhancement", Color: "00ff00", Description: "This is an enhancement"},
+					{Name: "question", Color: "0000ff", Description: "This is a question"},
+				},
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
@@ -201,7 +235,7 @@ Would create label "question" for repository "tnagatomi/mock-repo"
 				dryRun: tt.dryrun,
 			}
 			out := &bytes.Buffer{}
-			err := e.Create(out, tt.args.repoOption, tt.args.labelOption)
+			err := e.Create(out, tt.args.repos, tt.args.labels)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
@@ -224,8 +258,8 @@ Would create label "question" for repository "tnagatomi/mock-repo"
 
 func TestDelete(t *testing.T) {
 	type args struct {
-		repoOption  string
-		labelOption string
+		repos  []option.Repo
+		labels []string
 	}
 	tests := []struct {
 		name    string
@@ -243,8 +277,10 @@ func TestDelete(t *testing.T) {
 			name:   "single repository",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo",
-				labelOption: "bug,enhancement,question",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
+				labels: []string{"bug", "enhancement", "question"},
 			},
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
@@ -271,8 +307,11 @@ Summary: all operations completed successfully
 			name:   "multiple repositories",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/mock-repo-2",
-				labelOption: "bug,enhancement,question",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo-1"},
+					{Owner: "tnagatomi", Repo: "mock-repo-2"},
+				},
+				labels: []string{"bug", "enhancement", "question"},
 			},
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
@@ -305,8 +344,10 @@ Summary: all operations completed successfully
 			name:   "repository not found error",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/non-existent-repo",
-				labelOption: "bug,enhancement",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "non-existent-repo"},
+				},
+				labels: []string{"bug", "enhancement"},
 			},
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
@@ -331,8 +372,10 @@ Summary: 0 repositories succeeded, 1 failed
 			name:   "permission error",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/private-repo",
-				labelOption: "bug",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "private-repo"},
+				},
+				labels: []string{"bug"},
 			},
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
@@ -355,8 +398,12 @@ Summary: 0 repositories succeeded, 1 failed
 			name:   "multiple repositories with partial failure",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
-				labelOption: "bug",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "repo-1"},
+					{Owner: "tnagatomi", Repo: "repo-2"},
+					{Owner: "tnagatomi", Repo: "repo-3"},
+				},
+				labels: []string{"bug"},
 			},
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
@@ -386,8 +433,10 @@ Summary: 2 repositories succeeded, 1 failed
 			name:   "dry-run",
 			dryrun: true,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo",
-				labelOption: "bug,enhancement,question",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
+				labels: []string{"bug", "enhancement", "question"},
 			},
 			mock: &mock.MockAPI{
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
@@ -413,7 +462,7 @@ Would delete label "question" for repository "tnagatomi/mock-repo"
 				dryRun: tt.dryrun,
 			}
 			out := &bytes.Buffer{}
-			err := e.Delete(out, tt.args.repoOption, tt.args.labelOption)
+			err := e.Delete(out, tt.args.repos, tt.args.labels)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -435,8 +484,8 @@ Would delete label "question" for repository "tnagatomi/mock-repo"
 
 func TestSync(t *testing.T) {
 	type args struct {
-		repoOption  string
-		labelOption string
+		repos  []option.Repo
+		labels []option.Label
 	}
 	tests := []struct {
 		name    string
@@ -463,8 +512,14 @@ func TestSync(t *testing.T) {
 			name:   "multiple repositories with different existing labels",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/mock-repo-2",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo-1"},
+					{Owner: "tnagatomi", Repo: "mock-repo-2"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+					{Name: "enhancement", Color: "00ff00", Description: "This is an enhancement"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -523,8 +578,14 @@ Summary: all operations completed successfully
 			name:   "repository not found on list labels",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/non-existent-repo",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo-1"},
+					{Owner: "tnagatomi", Repo: "non-existent-repo"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+					{Name: "enhancement", Color: "00ff00", Description: "This is an enhancement"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -568,8 +629,13 @@ Summary: 1 repositories succeeded, 1 failed
 			name:   "permission error on update",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/private-repo-1,tnagatomi/private-repo-2",
-				labelOption: "bug:ff0000:This is a bug",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "private-repo-1"},
+					{Owner: "tnagatomi", Repo: "private-repo-2"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -609,8 +675,14 @@ Summary: 0 repositories succeeded, 2 failed
 			name:   "mixed errors during sync",
 			dryrun: false,
 			args: args{
-				repoOption:  "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
-				labelOption: "bug:ff0000:This is a bug",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "repo-1"},
+					{Owner: "tnagatomi", Repo: "repo-2"},
+					{Owner: "tnagatomi", Repo: "repo-3"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -666,8 +738,14 @@ Summary: 1 repositories succeeded, 2 failed
 			name:   "dry-run",
 			dryrun: true,
 			args: args{
-				repoOption:  "tnagatomi/mock-repo-1,tnagatomi/mock-repo-2",
-				labelOption: "bug:ff0000:This is a bug,enhancement:00ff00:This is an enhancement",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo-1"},
+					{Owner: "tnagatomi", Repo: "mock-repo-2"},
+				},
+				labels: []option.Label{
+					{Name: "bug", Color: "ff0000", Description: "This is a bug"},
+					{Name: "enhancement", Color: "00ff00", Description: "This is an enhancement"},
+				},
 			},
 			mock: &mock.MockAPI{
 				CreateLabelFunc: func(label option.Label, repo option.Repo) error {
@@ -716,7 +794,7 @@ Would create label "enhancement" for repository "tnagatomi/mock-repo-2"
 				dryRun: tt.dryrun,
 			}
 			out := &bytes.Buffer{}
-			err := e.Sync(out, tt.args.repoOption, tt.args.labelOption)
+			err := e.Sync(out, tt.args.repos, tt.args.labels)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Sync() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -762,7 +840,7 @@ Would create label "enhancement" for repository "tnagatomi/mock-repo-2"
 
 func TestEmpty(t *testing.T) {
 	type args struct {
-		repoOption string
+		repos []option.Repo
 	}
 	tests := []struct {
 		name    string
@@ -781,7 +859,9 @@ func TestEmpty(t *testing.T) {
 			name:   "single repository",
 			dryrun: false,
 			args: args{
-				repoOption: "tnagatomi/mock-repo",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -814,7 +894,10 @@ Summary: all operations completed successfully
 			name:   "multiple repository",
 			dryrun: false,
 			args: args{
-				repoOption: "tnagatomi/mock-repo-1,tnagatomi/mock-repo-2",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo-1"},
+					{Owner: "tnagatomi", Repo: "mock-repo-2"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -857,7 +940,9 @@ Summary: all operations completed successfully
 			name:   "repository not found on list",
 			dryrun: false,
 			args: args{
-				repoOption: "tnagatomi/non-existent-repo",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "non-existent-repo"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -881,7 +966,9 @@ Summary: 0 repositories succeeded, 1 failed
 			name:   "permission error on delete",
 			dryrun: false,
 			args: args{
-				repoOption: "tnagatomi/private-repo",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "private-repo"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -912,7 +999,11 @@ Summary: 0 repositories succeeded, 1 failed
 			name:   "multiple repositories with partial failure",
 			dryrun: false,
 			args: args{
-				repoOption: "tnagatomi/repo-1,tnagatomi/repo-2,tnagatomi/repo-3",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "repo-1"},
+					{Owner: "tnagatomi", Repo: "repo-2"},
+					{Owner: "tnagatomi", Repo: "repo-3"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -949,7 +1040,9 @@ Summary: 2 repositories succeeded, 1 failed
 			name:   "dry-run",
 			dryrun: true,
 			args: args{
-				repoOption: "tnagatomi/mock-repo",
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
 			},
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]string, error) {
@@ -981,7 +1074,7 @@ Would delete label "question" for repository "tnagatomi/mock-repo"
 				dryRun: tt.dryrun,
 			}
 			out := &bytes.Buffer{}
-			err := e.Empty(out, tt.args.repoOption)
+			err := e.Empty(out, tt.args.repos)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Sync() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/parser/label_json.go
+++ b/parser/label_json.go
@@ -1,0 +1,74 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/tnagatomi/gh-fuda/option"
+)
+
+// JSONLabel represents the JSON structure for a label
+type JSONLabel struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+// LabelFromJSON parses labels from a JSON file
+func LabelFromJSON(path string) ([]option.Label, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JSON file: %v", err)
+	}
+
+	var jsonLabels []JSONLabel
+	if err := json.Unmarshal(data, &jsonLabels); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %v", err)
+	}
+
+	var labels []option.Label
+	for i, jl := range jsonLabels {
+		if jl.Name == "" {
+			return nil, fmt.Errorf("label at index %d has empty name", i)
+		}
+
+		if jl.Color == "" {
+			return nil, fmt.Errorf("label %q has empty color", jl.Name)
+		}
+
+		if !isHexColor(jl.Color) {
+			return nil, fmt.Errorf("label %q has invalid color format: %s", jl.Name, jl.Color)
+		}
+
+		labels = append(labels, option.Label{
+			Name:        jl.Name,
+			Color:       jl.Color,
+			Description: jl.Description,
+		})
+	}
+
+	return labels, nil
+}

--- a/parser/label_json_test.go
+++ b/parser/label_json_test.go
@@ -25,6 +25,7 @@ package parser
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tnagatomi/gh-fuda/option"
@@ -168,7 +169,7 @@ func TestLabelFromJSON(t *testing.T) {
 			}
 
 			if tt.wantErr && tt.errContains != "" {
-				if err == nil || !contains(err.Error(), tt.errContains) {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("LabelFromJSON() error = %v, want error containing %q", err, tt.errContains)
 				}
 				return
@@ -195,12 +196,7 @@ func TestLabelFromJSON_FileNotFound(t *testing.T) {
 	if err == nil {
 		t.Error("LabelFromJSON() expected error for non-existent file, got nil")
 	}
-	if !contains(err.Error(), "failed to read JSON file") {
+	if !strings.Contains(err.Error(), "failed to read JSON file") {
 		t.Errorf("LabelFromJSON() error = %v, want error containing 'failed to read JSON file'", err)
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && s[:len(substr)] == substr ||
-		len(s) >= len(substr) && contains(s[1:], substr)
 }

--- a/parser/label_json_test.go
+++ b/parser/label_json_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tnagatomi/gh-fuda/option"
+)
+
+func TestLabelFromJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonContent string
+		want        []option.Label
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid JSON with multiple labels",
+			jsonContent: `[
+				{
+					"name": "Status: Completed",
+					"color": "2E7D32",
+					"description": "Work was started and finished"
+				},
+				{
+					"name": "Status: In Progress",
+					"color": "666699",
+					"description": "Work was started, is actively being worked on"
+				},
+				{
+					"name": "Priority: High",
+					"color": "FF8C00",
+					"description": ""
+				}
+			]`,
+			want: []option.Label{
+				{Name: "Status: Completed", Color: "2E7D32", Description: "Work was started and finished"},
+				{Name: "Status: In Progress", Color: "666699", Description: "Work was started, is actively being worked on"},
+				{Name: "Priority: High", Color: "FF8C00", Description: ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid JSON with single label",
+			jsonContent: `[
+				{
+					"name": "bug",
+					"color": "d73a4a",
+					"description": "Something isn't working"
+				}
+			]`,
+			want: []option.Label{
+				{Name: "bug", Color: "d73a4a", Description: "Something isn't working"},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "empty JSON array",
+			jsonContent: `[]`,
+			want:        []option.Label{},
+			wantErr:     false,
+		},
+		{
+			name: "label with empty name",
+			jsonContent: `[
+				{
+					"name": "",
+					"color": "FF0000",
+					"description": "Test"
+				}
+			]`,
+			want:        nil,
+			wantErr:     true,
+			errContains: "empty name",
+		},
+		{
+			name: "label with empty color",
+			jsonContent: `[
+				{
+					"name": "test",
+					"color": "",
+					"description": "Test"
+				}
+			]`,
+			want:        nil,
+			wantErr:     true,
+			errContains: "empty color",
+		},
+		{
+			name: "label with invalid color format",
+			jsonContent: `[
+				{
+					"name": "test",
+					"color": "GGGGGG",
+					"description": "Test"
+				}
+			]`,
+			want:        nil,
+			wantErr:     true,
+			errContains: "invalid color format",
+		},
+		{
+			name: "label with invalid color length",
+			jsonContent: `[
+				{
+					"name": "test",
+					"color": "FF00",
+					"description": "Test"
+				}
+			]`,
+			want:        nil,
+			wantErr:     true,
+			errContains: "invalid color format",
+		},
+		{
+			name:        "invalid JSON format",
+			jsonContent: `{"invalid": "json"}`,
+			want:        nil,
+			wantErr:     true,
+			errContains: "failed to parse JSON",
+		},
+		{
+			name:        "malformed JSON",
+			jsonContent: `[{invalid json}]`,
+			want:        nil,
+			wantErr:     true,
+			errContains: "failed to parse JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			jsonFile := filepath.Join(tmpDir, "labels.json")
+			err := os.WriteFile(jsonFile, []byte(tt.jsonContent), 0644)
+			if err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+
+			got, err := LabelFromJSON(jsonFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LabelFromJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && tt.errContains != "" {
+				if err == nil || !contains(err.Error(), tt.errContains) {
+					t.Errorf("LabelFromJSON() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("LabelFromJSON() returned %d labels, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i, label := range got {
+				if label.Name != tt.want[i].Name ||
+					label.Color != tt.want[i].Color ||
+					label.Description != tt.want[i].Description {
+					t.Errorf("LabelFromJSON() label[%d] = %+v, want %+v", i, label, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLabelFromJSON_FileNotFound(t *testing.T) {
+	_, err := LabelFromJSON("/non/existent/file.json")
+	if err == nil {
+		t.Error("LabelFromJSON() expected error for non-existent file, got nil")
+	}
+	if !contains(err.Error(), "failed to read JSON file") {
+		t.Errorf("LabelFromJSON() error = %v, want error containing 'failed to read JSON file'", err)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && s[:len(substr)] == substr ||
+		len(s) >= len(substr) && contains(s[1:], substr)
+}


### PR DESCRIPTION
## Summary
- Add JSON file support for `create` and `sync` commands
- Enable bulk label operations using JSON configuration files
- Improve API design for better extensibility

Fixes https://github.com/tnagatomi/gh-fuda/issues/34

## Changes
- Add `--json <path>` flag to `create` and `sync` commands
- Support JSON format with `name`, `color`, and `description` fields
- Make `--json` and `-l` flags mutually exclusive
- **Breaking change**: Update Executor API to accept structured types (`[]option.Label`, `[]option.Repo`) instead of strings
- Update `delete` and `empty` commands to use structured types for consistency
- Add comprehensive tests for JSON parsing functionality
- Update documentation with usage examples

## JSON Format Example
```json
[
  {
    "name": "bug",
    "color": "d73a4a",
    "description": "Something isn't working"
  },
  {
    "name": "enhancement",
    "color": "a2eeef",
    "description": "New feature or request"
  }
]
```

## Usage
```bash
# Create labels from JSON file
gh fuda create -R "owner/repo" --json labels.json

# Sync labels from JSON file
gh fuda sync -R "owner/repo" --json labels.json
```

## Breaking Changes
The Executor methods now accept structured types instead of strings. This is a breaking change but improves extensibility for future format support (e.g., YAML).

Since there are no external dependents (checked GitHub Dependents), this breaking change should not impact any external users.

## Test Plan
- [x] Added comprehensive unit tests for JSON parsing
- [x] Updated all existing tests to work with new API
- [x] Manual testing with various JSON files
- [x] Tested error cases (invalid JSON, missing fields, invalid colors)

🤖 Generated with [Claude Code](https://claude.ai/code)