### PR TITLE
Add list command to display repository labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Login to GitHub with `gh auth login` (ref. [gh manual of gh auth login](https://
 
 ### List of Commands
 
+#### List Labels
+
+```bash
+gh fuda list
+```
+
+List existing labels from the specified repositories.
+
+##### Example
+
+```bash
+gh fuda list -R "owner1/repo1,owner1/repo2,owner2/repo1"
+```
+
 #### Create Labels
 
 ```bash

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cli/go-gh/v2/pkg/api"
+	"github.com/spf13/cobra"
+	"github.com/tnagatomi/gh-fuda/executor"
+	"github.com/tnagatomi/gh-fuda/parser"
+)
+
+// NewListCmd initialize the list command
+func NewListCmd(out io.Writer) *cobra.Command {
+	var listCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List existing labels from the specified repositories",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoList, err := parser.Repo(repos)
+			if err != nil {
+				return fmt.Errorf("failed to parse repos option: %v", err)
+			}
+
+			client, err := api.NewHTTPClient(api.ClientOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create gh http client: %v", err)
+			}
+
+			e, err := executor.NewExecutor(client, false)
+			if err != nil {
+				return fmt.Errorf("failed to create executor: %v", err)
+			}
+
+			err = e.List(out, repoList)
+			if err != nil {
+				return fmt.Errorf("failed to list labels: %v", err)
+			}
+
+			return nil
+		},
+	}
+	return listCmd
+}
+
+func init() {
+	listCmd := NewListCmd(os.Stdout)
+	rootCmd.AddCommand(listCmd)
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -146,27 +146,27 @@ func (e *Executor) Sync(out io.Writer, repos []option.Repo, labels []option.Labe
 
 		// Delete labels not in the new set
 		for _, existing := range existingLabels {
-			if labelNameExists(existing, labels) {
+			if labelNameExists(existing.Name, labels) {
 				continue
 			}
 
 			if e.dryRun {
-				_, _ = fmt.Fprintf(out, "Would delete label %q for repository %q\n", existing, repo)
+				_, _ = fmt.Fprintf(out, "Would delete label %q for repository %q\n", existing.Name, repo)
 				continue
 			}
 
-			err = e.api.DeleteLabel(existing, repo)
+			err = e.api.DeleteLabel(existing.Name, repo)
 			if err != nil {
 				repoResult.Errors = append(repoResult.Errors, err)
-				_, _ = fmt.Fprintf(out, "Failed to delete label %q for repository %q: %v\n", existing, repo, err)
+				_, _ = fmt.Fprintf(out, "Failed to delete label %q for repository %q: %v\n", existing.Name, repo, err)
 			} else {
-				_, _ = fmt.Fprintf(out, "Deleted label %q for repository %q\n", existing, repo)
+				_, _ = fmt.Fprintf(out, "Deleted label %q for repository %q\n", existing.Name, repo)
 			}
 		}
 
 		// Create or update labels
 		for _, label := range labels {
-			if stringExists(label.Name, existingLabels) {
+			if labelExists(label.Name, existingLabels) {
 				if e.dryRun {
 					_, _ = fmt.Fprintf(out, "Would update label %q for repository %q\n", label, repo)
 					continue
@@ -208,6 +208,45 @@ func (e *Executor) Sync(out io.Writer, repos []option.Repo, labels []option.Labe
 	return er.Err()
 }
 
+// List lists labels across multiple repositories
+func (e *Executor) List(out io.Writer, repos []option.Repo) error {
+	er := NewExecutionResult()
+
+	for _, repo := range repos {
+		repoResult := &RepoResult{
+			Repo:   repo.String(),
+			Errors: nil,
+		}
+
+		labels, err := e.api.ListLabels(repo)
+		if err != nil {
+			repoResult.Errors = append(repoResult.Errors, err)
+			_, _ = fmt.Fprintf(out, "Failed to list labels for repository %q: %v\n", repo, err)
+			er.AddRepoResult(repoResult)
+			continue
+		}
+
+		if len(labels) == 0 {
+			_, _ = fmt.Fprintf(out, "Repository %q has no labels\n", repo)
+		} else {
+			_, _ = fmt.Fprintf(out, "Labels for repository %q:\n", repo)
+			for _, label := range labels {
+				if label.Description == "" {
+					_, _ = fmt.Fprintf(out, "  %s (#%s)\n", label.Name, label.Color)
+				} else {
+					_, _ = fmt.Fprintf(out, "  %s (#%s) - %s\n", label.Name, label.Color, label.Description)
+				}
+			}
+		}
+
+		er.AddRepoResult(repoResult)
+	}
+
+	_, _ = fmt.Fprintf(out, "\n%s\n", er.Summary())
+
+	return er.Err()
+}
+
 // Empty empties labels across multiple repositories
 func (e *Executor) Empty(out io.Writer, repos []option.Repo) error {
 	er := NewExecutionResult()
@@ -242,16 +281,16 @@ func (e *Executor) emptyLabels(out io.Writer, repos []option.Repo) []*RepoResult
 
 		for _, label := range labels {
 			if e.dryRun {
-				_, _ = fmt.Fprintf(out, "Would delete label %q for repository %q\n", label, repo)
+				_, _ = fmt.Fprintf(out, "Would delete label %q for repository %q\n", label.Name, repo)
 				continue
 			}
 
-			err := e.api.DeleteLabel(label, repo)
+			err := e.api.DeleteLabel(label.Name, repo)
 			if err != nil {
 				repoResult.Errors = append(repoResult.Errors, err)
-				_, _ = fmt.Fprintf(out, "Failed to delete label %q for repository %q: %v\n", label, repo, err)
+				_, _ = fmt.Fprintf(out, "Failed to delete label %q for repository %q: %v\n", label.Name, repo, err)
 			} else {
-				_, _ = fmt.Fprintf(out, "Deleted label %q for repository %q\n", label, repo)
+				_, _ = fmt.Fprintf(out, "Deleted label %q for repository %q\n", label.Name, repo)
 			}
 		}
 
@@ -271,10 +310,10 @@ func labelNameExists(name string, labels []option.Label) bool {
 	return false
 }
 
-// stringExists checks if a string exists in a slice of strings
-func stringExists(target string, strings []string) bool {
-	for _, s := range strings {
-		if target == s {
+// labelExists checks if a label name exists in a slice of labels
+func labelExists(name string, labels []option.Label) bool {
+	for _, label := range labels {
+		if name == label.Name {
 			return true
 		}
 	}

--- a/internal/mock/api.go
+++ b/internal/mock/api.go
@@ -21,7 +21,7 @@ type MockAPI struct {
 		Repo  option.Repo
 	}
 
-	ListLabelsFunc func(repo option.Repo) ([]string, error)
+	ListLabelsFunc func(repo option.Repo) ([]option.Label, error)
 	ListLabelsCalls []struct {
 		Repo option.Repo
 	}
@@ -66,7 +66,7 @@ func (m *MockAPI) DeleteLabel(label string, repo option.Repo) error {
 	return nil
 }
 
-func (m *MockAPI) ListLabels(repo option.Repo) ([]string, error) {
+func (m *MockAPI) ListLabels(repo option.Repo) ([]option.Label, error) {
 	m.ListLabelsCalls = append(m.ListLabelsCalls, struct {
 		Repo option.Repo
 	}{repo})


### PR DESCRIPTION
## Summary

- Add new `list` command to display all labels with their colors and descriptions
- **BREAKING CHANGE**: Update `ListLabels` API to return `[]option.Label` instead of `[]string`
- Implement pagination support for repositories with more than 100 labels

## Motivation

Fixes #35 - Users need a way to view existing labels before performing operations like sync or create. This makes the tool more user-friendly by allowing users to inspect the current state of labels across repositories.

## Changes

### New Features
- Add `gh fuda list` command that displays all labels with their details:
  - Shows label name, color code, and description (if available)
  - Format: `labelName (#color)` or `labelName (#color) - description`
  - No dry-run mode needed as it's a read-only operation

### Breaking Changes
- `api.APIClient.ListLabels` now returns `([]option.Label, error)` instead of `([]string, error)`
- This requires a major version bump to v2.0.0

### Implementation Details
- Add pagination support in `ListLabels` to handle repositories with >100 labels
- Update all existing code that uses `ListLabels` to work with the new return type
- Add comprehensive test coverage including pagination test cases
- Update documentation in README.md and CLAUDE.md

## Test Plan

- [x] All existing tests pass
- [x] New tests added for list command functionality
- [x] Pagination test case added for >100 labels
- [ ] Manual testing with real repositories

🤖 Generated with [Claude Code](https://claude.ai/code)