### PR TITLE
Add YAML file support for labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,11 @@ func TestFunctionName(t *testing.T) {
 - Simplified error messages without redundant details (e.g., "repository not found" instead of "repository 'owner/repo' not found")
 - Command usage is not displayed for runtime errors (only for argument/flag errors)
 
-## JSON File Support
+## File Input Support
 
-The `create` and `sync` commands support JSON file input for labels:
+The `create` and `sync` commands support both JSON and YAML file input for labels.
+
+### JSON Format
 
 ```json
 [
@@ -124,11 +126,25 @@ The `create` and `sync` commands support JSON file input for labels:
 ]
 ```
 
-Usage:
-- `gh fuda create -R owner/repo --json labels.json`
-- `gh fuda sync -R owner/repo --json labels.json`
+### YAML Format
 
-Note: `--json` and `-l/--labels` flags are mutually exclusive.
+```yaml
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+```
+
+### Usage
+
+- `gh fuda create -R owner/repo --json labels.json`
+- `gh fuda create -R owner/repo --yaml labels.yaml`
+- `gh fuda sync -R owner/repo --json labels.json`
+- `gh fuda sync -R owner/repo --yaml labels.yaml`
+
+Note: `--json`, `--yaml`, and `-l/--labels` flags are mutually exclusive. You must use exactly one of these options.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Create specified labels to the specified repositories.
 
 - `-l`, `--labels`: Specify the labels to create in the format of `'label1:color1:description1[,label2:color2:description2,...]'` (description can be omitted)
 - `--json`: Specify the path to a JSON file containing labels to create
+- `--yaml`: Specify the path to a YAML file containing labels to create
+
+**Note**: `--json`, `--yaml`, and `-l/--labels` flags are mutually exclusive. You must use exactly one of these options.
 
 ##### Example
 
@@ -56,6 +59,9 @@ gh fuda create -R "owner1/repo1,owner1/repo2,owner2/repo1" -l "label1:ff0000:des
 
 # Using JSON file
 gh fuda create -R "owner1/repo1,owner1/repo2,owner2/repo1" --json labels.json
+
+# Using YAML file
+gh fuda create -R "owner1/repo1,owner1/repo2,owner2/repo1" --yaml labels.yaml
 ```
 
 ##### JSON File Format
@@ -78,6 +84,20 @@ gh fuda create -R "owner1/repo1,owner1/repo2,owner2/repo1" --json labels.json
     "description": "Improvements or additions to documentation"
   }
 ]
+```
+
+##### YAML File Format
+
+```yaml
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+- name: documentation
+  color: 07c
+  description: Improvements or additions to documentation
 ```
 
 #### Delete Labels
@@ -111,7 +131,10 @@ Sync the labels in the specified repositories with the specified labels.
 
 - `-l`, `--labels`: Specify the labels to set in the format of `'label1:color1:description1[,label2:color2:description2,...]'` (description can be omitted)
 - `--json`: Specify the path to a JSON file containing labels to sync
+- `--yaml`: Specify the path to a YAML file containing labels to sync
 - `--force`: Do not prompt for confirmation
+
+**Note**: `--json`, `--yaml`, and `-l/--labels` flags are mutually exclusive. You must use exactly one of these options.
 
 ##### Example
 
@@ -121,11 +144,14 @@ gh fuda sync -R "owner1/repo1,owner1/repo2,owner2/repo1" -l "label1:ff0000:descr
 
 # Using JSON file
 gh fuda sync -R "owner1/repo1,owner1/repo2,owner2/repo1" --json labels.json
+
+# Using YAML file
+gh fuda sync -R "owner1/repo1,owner1/repo2,owner2/repo1" --yaml labels.yaml
 ```
 
-##### JSON File Format
+##### File Formats
 
-The JSON file format is the same as the one used for the `create` command. See the [Create Labels](#create-labels) section for details.
+The JSON and YAML file formats are the same as those used for the `create` command. See the [Create Labels](#create-labels) section for details.
 
 #### Empty Labels
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -41,11 +41,23 @@ func NewCreateCmd(out io.Writer) *cobra.Command {
 		Use:   "create",
 		Short: "Create specified labels to the specified repositories",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if jsonPath != "" && labels != "" {
-				return errors.New("--labels (-l) and --json cannot be used together")
+			// Check that only one input method is specified
+			inputCount := 0
+			if labels != "" {
+				inputCount++
 			}
-			if jsonPath == "" && labels == "" {
-				return errors.New("either --labels (-l) or --json must be specified")
+			if jsonPath != "" {
+				inputCount++
+			}
+			if yamlPath != "" {
+				inputCount++
+			}
+			
+			if inputCount > 1 {
+				return errors.New("--labels (-l), --json, and --yaml cannot be used together")
+			}
+			if inputCount == 0 {
+				return errors.New("one of --labels (-l), --json, or --yaml must be specified")
 			}
 
 			var labelList []option.Label
@@ -54,6 +66,11 @@ func NewCreateCmd(out io.Writer) *cobra.Command {
 				labelList, err = parser.LabelFromJSON(jsonPath)
 				if err != nil {
 					return fmt.Errorf("failed to parse JSON file: %v", err)
+				}
+			} else if yamlPath != "" {
+				labelList, err = parser.LabelFromYAML(yamlPath)
+				if err != nil {
+					return fmt.Errorf("failed to parse YAML file: %v", err)
 				}
 			} else {
 				labelList, err = parser.Label(labels)
@@ -94,4 +111,5 @@ func init() {
 
 	createCmd.Flags().StringVarP(&labels, "labels", "l", "", "Specify the labels to create in the format of 'label1:color1:description1[,label2:color2:description2,...]' (description can be omitted)")
 	createCmd.Flags().StringVar(&jsonPath, "json", "", "Specify the path to a JSON file containing labels to create")
+	createCmd.Flags().StringVar(&yamlPath, "yaml", "", "Specify the path to a YAML file containing labels to create")
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -22,7 +22,6 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,7 +29,6 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/spf13/cobra"
 	"github.com/tnagatomi/gh-fuda/executor"
-	"github.com/tnagatomi/gh-fuda/option"
 	"github.com/tnagatomi/gh-fuda/parser"
 )
 
@@ -41,42 +39,9 @@ func NewCreateCmd(out io.Writer) *cobra.Command {
 		Use:   "create",
 		Short: "Create specified labels to the specified repositories",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Check that only one input method is specified
-			inputCount := 0
-			if labels != "" {
-				inputCount++
-			}
-			if jsonPath != "" {
-				inputCount++
-			}
-			if yamlPath != "" {
-				inputCount++
-			}
-			
-			if inputCount > 1 {
-				return errors.New("--labels (-l), --json, and --yaml cannot be used together")
-			}
-			if inputCount == 0 {
-				return errors.New("one of --labels (-l), --json, or --yaml must be specified")
-			}
-
-			var labelList []option.Label
-			var err error
-			if jsonPath != "" {
-				labelList, err = parser.LabelFromJSON(jsonPath)
-				if err != nil {
-					return fmt.Errorf("failed to parse JSON file: %v", err)
-				}
-			} else if yamlPath != "" {
-				labelList, err = parser.LabelFromYAML(yamlPath)
-				if err != nil {
-					return fmt.Errorf("failed to parse YAML file: %v", err)
-				}
-			} else {
-				labelList, err = parser.Label(labels)
-				if err != nil {
-					return fmt.Errorf("failed to parse labels option: %v", err)
-				}
+			labelList, err := parseLabelsInput(labels, jsonPath, yamlPath)
+			if err != nil {
+				return err
 			}
 
 			repoList, err := parser.Repo(repos)

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCreateCmd_MutuallyExclusiveFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "json and yaml together",
+			args:        []string{"create", "--json", "labels.json", "--yaml", "labels.yaml", "-R", "owner/repo"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "json and labels together",
+			args:        []string{"create", "--json", "labels.json", "--labels", "bug:ff0000", "-R", "owner/repo"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "yaml and labels together",
+			args:        []string{"create", "--yaml", "labels.yaml", "--labels", "bug:ff0000", "-R", "owner/repo"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "all three together",
+			args:        []string{"create", "--json", "labels.json", "--yaml", "labels.yaml", "--labels", "bug:ff0000", "-R", "owner/repo"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "no input method specified",
+			args:        []string{"create", "-R", "owner/repo"},
+			wantErr:     true,
+			errContains: "one of --labels (-l), --json, or --yaml must be specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset flags for each test
+			labels = ""
+			jsonPath = ""
+			yamlPath = ""
+			repos = ""
+
+			var out bytes.Buffer
+			// Use rootCmd to get all flags properly registered
+			rootCmd.SetArgs(tt.args)
+			rootCmd.SetOut(&out)
+			rootCmd.SetErr(&out)
+
+			err := rootCmd.Execute()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && tt.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Execute() error = %v, want error containing %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	force  bool
 	labels string
 	jsonPath string
+	yamlPath string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -22,14 +22,12 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/tnagatomi/gh-fuda/executor"
-	"github.com/tnagatomi/gh-fuda/option"
 	"github.com/tnagatomi/gh-fuda/parser"
 
 	"github.com/spf13/cobra"
@@ -41,42 +39,9 @@ func NewSyncCmd(in io.Reader, out io.Writer) *cobra.Command {
 		Use:   "sync",
 		Short: "Sync the labels in the specified repositories with the specified labels",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Check that only one input method is specified
-			inputCount := 0
-			if labels != "" {
-				inputCount++
-			}
-			if jsonPath != "" {
-				inputCount++
-			}
-			if yamlPath != "" {
-				inputCount++
-			}
-			
-			if inputCount > 1 {
-				return errors.New("--labels (-l), --json, and --yaml cannot be used together")
-			}
-			if inputCount == 0 {
-				return errors.New("one of --labels (-l), --json, or --yaml must be specified")
-			}
-
-			var labelList []option.Label
-			var err error
-			if jsonPath != "" {
-				labelList, err = parser.LabelFromJSON(jsonPath)
-				if err != nil {
-					return fmt.Errorf("failed to parse JSON file: %v", err)
-				}
-			} else if yamlPath != "" {
-				labelList, err = parser.LabelFromYAML(yamlPath)
-				if err != nil {
-					return fmt.Errorf("failed to parse YAML file: %v", err)
-				}
-			} else {
-				labelList, err = parser.Label(labels)
-				if err != nil {
-					return fmt.Errorf("failed to parse labels option: %v", err)
-				}
+			labelList, err := parseLabelsInput(labels, jsonPath, yamlPath)
+			if err != nil {
+				return err
 			}
 
 			repoList, err := parser.Repo(repos)

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSyncCmd_MutuallyExclusiveFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "json and yaml together",
+			args:        []string{"sync", "--json", "labels.json", "--yaml", "labels.yaml", "-R", "owner/repo", "--force"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "json and labels together",
+			args:        []string{"sync", "--json", "labels.json", "--labels", "bug:ff0000", "-R", "owner/repo", "--force"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "yaml and labels together",
+			args:        []string{"sync", "--yaml", "labels.yaml", "--labels", "bug:ff0000", "-R", "owner/repo", "--force"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "all three together",
+			args:        []string{"sync", "--json", "labels.json", "--yaml", "labels.yaml", "--labels", "bug:ff0000", "-R", "owner/repo", "--force"},
+			wantErr:     true,
+			errContains: "cannot be used together",
+		},
+		{
+			name:        "no input method specified",
+			args:        []string{"sync", "-R", "owner/repo", "--force"},
+			wantErr:     true,
+			errContains: "one of --labels (-l), --json, or --yaml must be specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset flags for each test
+			labels = ""
+			jsonPath = ""
+			yamlPath = ""
+			repos = ""
+			force = false
+
+			var out bytes.Buffer
+			// Use rootCmd to get all flags properly registered
+			rootCmd.SetArgs(tt.args)
+			rootCmd.SetOut(&out)
+			rootCmd.SetErr(&out)
+
+			err := rootCmd.Execute()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && tt.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Execute() error = %v, want error containing %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}

--- a/parser/label_yaml.go
+++ b/parser/label_yaml.go
@@ -1,0 +1,74 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package parser
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tnagatomi/gh-fuda/option"
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLLabel represents the YAML structure for a label
+type YAMLLabel struct {
+	Name        string `yaml:"name"`
+	Color       string `yaml:"color"`
+	Description string `yaml:"description"`
+}
+
+// LabelFromYAML parses labels from a YAML file
+func LabelFromYAML(path string) ([]option.Label, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read YAML file: %v", err)
+	}
+
+	var yamlLabels []YAMLLabel
+	if err := yaml.Unmarshal(data, &yamlLabels); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %v", err)
+	}
+
+	labels := make([]option.Label, 0, len(yamlLabels))
+	for i, yl := range yamlLabels {
+		if yl.Name == "" {
+			return nil, fmt.Errorf("label at index %d has empty name", i)
+		}
+
+		if yl.Color == "" {
+			return nil, fmt.Errorf("label %q has empty color", yl.Name)
+		}
+
+		if !isHexColor(yl.Color) {
+			return nil, fmt.Errorf("label %q has invalid color format: %s", yl.Name, yl.Color)
+		}
+
+		labels = append(labels, option.Label{
+			Name:        yl.Name,
+			Color:       yl.Color,
+			Description: yl.Description,
+		})
+	}
+
+	return labels, nil
+}

--- a/parser/label_yaml_test.go
+++ b/parser/label_yaml_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tnagatomi/gh-fuda/option"
+)
+
+func TestLabelFromYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlContent string
+		want        []option.Label
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid YAML with multiple labels",
+			yamlContent: `- name: bug
+  color: d73a4a
+  description: Something isn't working
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation`,
+			want: []option.Label{
+				{Name: "bug", Color: "d73a4a", Description: "Something isn't working"},
+				{Name: "enhancement", Color: "a2eeef", Description: "New feature or request"},
+				{Name: "documentation", Color: "0075ca", Description: "Improvements or additions to documentation"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid YAML with label without description",
+			yamlContent: `- name: bug
+  color: d73a4a
+- name: feature
+  color: a2eeef
+  description: A new feature`,
+			want: []option.Label{
+				{Name: "bug", Color: "d73a4a", Description: ""},
+				{Name: "feature", Color: "a2eeef", Description: "A new feature"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid YAML with 3-char hex colors",
+			yamlContent: `- name: bug
+  color: f00
+  description: Critical bug
+- name: feature
+  color: 0f0
+  description: New feature`,
+			want: []option.Label{
+				{Name: "bug", Color: "f00", Description: "Critical bug"},
+				{Name: "feature", Color: "0f0", Description: "New feature"},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "empty YAML array",
+			yamlContent: `[]`,
+			want:        []option.Label{},
+			wantErr:     false,
+		},
+		{
+			name: "invalid YAML syntax",
+			yamlContent: `- name: bug
+  color d73a4a
+  description: Invalid syntax`,
+			wantErr:     true,
+			errContains: "failed to parse YAML",
+		},
+		{
+			name: "label with empty name",
+			yamlContent: `- name: ""
+  color: d73a4a
+  description: No name`,
+			wantErr:     true,
+			errContains: "has empty name",
+		},
+		{
+			name: "label with missing name field",
+			yamlContent: `- color: d73a4a
+  description: No name field`,
+			wantErr:     true,
+			errContains: "has empty name",
+		},
+		{
+			name: "label with empty color",
+			yamlContent: `- name: bug
+  color: ""
+  description: No color`,
+			wantErr:     true,
+			errContains: "has empty color",
+		},
+		{
+			name: "label with missing color field",
+			yamlContent: `- name: bug
+  description: No color field`,
+			wantErr:     true,
+			errContains: "has empty color",
+		},
+		{
+			name: "label with invalid hex color",
+			yamlContent: `- name: bug
+  color: gggggg
+  description: Invalid hex`,
+			wantErr:     true,
+			errContains: "invalid color format",
+		},
+		{
+			name: "label with invalid color length",
+			yamlContent: `- name: bug
+  color: ff
+  description: Too short`,
+			wantErr:     true,
+			errContains: "invalid color format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary YAML file
+			tmpDir := t.TempDir()
+			yamlFile := filepath.Join(tmpDir, "labels.yaml")
+			err := os.WriteFile(yamlFile, []byte(tt.yamlContent), 0644)
+			if err != nil {
+				t.Fatalf("failed to create test file: %v", err)
+			}
+
+			// Test the function
+			got, err := LabelFromYAML(yamlFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LabelFromYAML() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && tt.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("LabelFromYAML() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("LabelFromYAML() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLabelFromYAML_FileReadError(t *testing.T) {
+	// Test with non-existent file
+	_, err := LabelFromYAML("/non/existent/file.yaml")
+	if err == nil {
+		t.Error("LabelFromYAML() should return error for non-existent file")
+		return
+	}
+	if !strings.Contains(err.Error(), "failed to read YAML file") {
+		t.Errorf("LabelFromYAML() error = %v, want error containing 'failed to read YAML file'", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add support for YAML file format in create and sync commands
- Extract duplicate validation logic to a common function
- Maintain backward compatibility with existing JSON and inline label formats

## Changes

### New Features
- Add `--yaml` flag to `create` and `sync` commands for YAML file input
- Implement YAML parser (`parser/label_yaml.go`) with same validation rules as JSON parser
- Support YAML format for label definitions:
  ```yaml
  - name: bug
    color: d73a4a
    description: Something isn't working
  ```

### Improvements
- Extract label input validation logic to `parseLabelsInput()` function in `cmd/helper.go`
- Eliminate ~70 lines of duplicate code between `create.go` and `sync.go`
- Ensure `--json`, `--yaml`, and `--labels` flags are mutually exclusive

### Testing
- Add comprehensive unit tests for YAML parsing functionality
- Add command-level tests for flag mutual exclusion
- Manual testing completed with real repositories

### Documentation
- Update README.md with YAML format examples and usage
- Update CLAUDE.md with YAML support documentation

## Test Plan

- [x] Unit tests pass for YAML parser
- [x] Command-level tests pass for flag validation
- [x] Manual testing with real repositories:
  - [x] Create labels from YAML file
  - [x] Sync labels from YAML file
  - [x] Verify mutual exclusion of input flags
- [x] All existing tests continue to pass
- [x] Backward compatibility maintained for JSON and inline formats

🤖 Generated with [Claude Code](https://claude.ai/code)