### PR TITLE
feat: add --force flag to create command for updating existing labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ The codebase follows a clean layered architecture:
    - Each command (list, create, delete, sync, empty) has its own file
    - Commands parse arguments and delegate to executor
    - `create` and `sync` commands support JSON file input via `--json` flag
+   - `create` command supports `--force` flag to update existing labels instead of failing
    - `list` command does not use dry-run mode as it's a read-only operation
 
 2. **executor/** - Business logic layer
@@ -89,7 +90,7 @@ func TestFunctionName(t *testing.T) {
   - `ListLabels(repo option.Repo) ([]option.Label, error)` - Returns full label details including color and description
 - Executor methods accept structured data instead of strings:
   - `List(out io.Writer, repos []option.Repo) error` - Lists all labels with their details
-  - `Create(out io.Writer, repos []option.Repo, labels []option.Label) error`
+  - `Create(out io.Writer, repos []option.Repo, labels []option.Label, force bool) error` - Creates labels; with force=true, updates existing labels instead of failing
   - `Delete(out io.Writer, repos []option.Repo, labels []string) error`
   - `Sync(out io.Writer, repos []option.Repo, labels []option.Label) error`
   - `Empty(out io.Writer, repos []option.Repo) error`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Create specified labels to the specified repositories.
 - `-l`, `--labels`: Specify the labels to create in the format of `'label1:color1:description1[,label2:color2:description2,...]'` (description can be omitted)
 - `--json`: Specify the path to a JSON file containing labels to create
 - `--yaml`: Specify the path to a YAML file containing labels to create
+- `-f`, `--force`: Update the label color and description if label already exists
 
 **Note**: `--json`, `--yaml`, and `-l/--labels` flags are mutually exclusive. You must use exactly one of these options.
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -59,7 +59,7 @@ func NewCreateCmd(out io.Writer) *cobra.Command {
 				return fmt.Errorf("failed to create executor: %v", err)
 			}
 
-			err = e.Create(out, repoList, labelList)
+			err = e.Create(out, repoList, labelList, force)
 			if err != nil {
 				return fmt.Errorf("failed to create labels: %v", err)
 			}
@@ -77,4 +77,5 @@ func init() {
 	createCmd.Flags().StringVarP(&labels, "labels", "l", "", "Specify the labels to create in the format of 'label1:color1:description1[,label2:color2:description2,...]' (description can be omitted)")
 	createCmd.Flags().StringVar(&jsonPath, "json", "", "Specify the path to a JSON file containing labels to create")
 	createCmd.Flags().StringVar(&yamlPath, "yaml", "", "Specify the path to a YAML file containing labels to create")
+	createCmd.Flags().BoolVarP(&force, "force", "f", false, "Update the label color and description if label already exists")
 }


### PR DESCRIPTION
## Summary

- Fixes #31
- Add `--force` (`-f`) flag to `create` command that updates existing labels instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--force` / `-f` flag to the Create Labels command. When enabled, the command automatically updates the color and description of labels that already exist in target repositories, rather than failing with an error. Label management workflows can now run without requiring manual deletion and recreation of labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->