### PR TITLE
Add automatic retry with exponential backoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,17 @@ func TestFunctionName(t *testing.T) {
 - Summary is displayed at the end showing success/failure counts (format: "Summary: X repositories succeeded, Y failed")
 - Exit code 1 if any operations failed
 - Custom error types for common GitHub API errors (404, 403, etc.) with `ResourceType` enum to distinguish between repository and label errors
+- `RateLimitError` (HTTP 429) and `TransientError` (HTTP 5xx, network failures) are treated as retryable
 - Simplified error messages without redundant details (e.g., "repository not found" instead of "repository 'owner/repo' not found")
 - Command usage is not displayed for runtime errors (only for argument/flag errors)
+
+## Retry Behavior
+
+- All GraphQL queries and mutations are wrapped with `withRetry` in `api/retry.go`
+- Retries on `RateLimitError` and `TransientError` only; other errors return immediately
+- Default config: 3 attempts, exponential backoff starting at 1s and capped at 8s (1s, 2s, 4s)
+- The `sleep` function is injectable so unit tests can verify retry sequences without consuming real time
+- Because `shurcooL-graphql` (used by go-gh's `Query`/`Mutate`) does not surface `*api.HTTPError` for non-2xx responses, `parseShurcoolStatusCode` recovers the status code from its plain error message so 429/5xx still map to typed errors
 
 ## Label Input Support
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,11 @@ func TestFunctionName(t *testing.T) {
 ## Retry Behavior
 
 - All GraphQL queries and mutations are wrapped with `withRetry` in `api/retry.go`
-- Retries on `RateLimitError` and `TransientError` only; other errors return immediately
 - Default config: 3 attempts, exponential backoff starting at 1s and capped at 8s (1s, 2s, 4s)
 - The `sleep` function is injectable so unit tests can verify retry sequences without consuming real time
+- Idempotent operations (queries, `UpdateLabel`, `AddLabelsToLabelable`, `RemoveLabelsFromLabelable`) retry on both `RateLimitError` and `TransientError`
+- Non-idempotent mutations (`CreateLabel`, `DeleteLabel`) retry only on `RateLimitError`. Retrying these on transient/network errors could observe `AlreadyExists`/`NotFound` from a previously-committed call and report a false failure; rate limits are gateway-rejected before reaching the data layer, so retrying them is safe
+- `net.Error` (timeouts, connection reset, DNS, context deadline) is mapped to `TransientError` in `wrapGraphQLError` so the retry classifier sees it consistently
 - Because `shurcooL-graphql` (used by go-gh's `Query`/`Mutate`) does not surface `*api.HTTPError` for non-2xx responses, `parseShurcoolStatusCode` recovers the status code from its plain error message so 429/5xx still map to typed errors
 
 ## Label Input Support

--- a/api/errors.go
+++ b/api/errors.go
@@ -67,6 +67,27 @@ func (e *RateLimitError) Error() string {
 	return "rate limit exceeded"
 }
 
+// TransientError indicates a temporary failure such as a 5xx response or
+// a network error that may succeed if retried.
+type TransientError struct {
+	StatusCode int
+	Cause      error
+}
+
+func (e *TransientError) Error() string {
+	if e.StatusCode != 0 {
+		return fmt.Sprintf("transient API error (HTTP %d)", e.StatusCode)
+	}
+	if e.Cause != nil {
+		return fmt.Sprintf("transient API error: %s", e.Cause.Error())
+	}
+	return "transient API error"
+}
+
+func (e *TransientError) Unwrap() error {
+	return e.Cause
+}
+
 // AlreadyExistsError indicates resource already exists
 type AlreadyExistsError struct {
 	ResourceType ResourceType
@@ -110,6 +131,11 @@ func IsForbidden(err error) bool {
 func IsRateLimit(err error) bool {
 	var rateLimitErr *RateLimitError
 	return errors.As(err, &rateLimitErr)
+}
+
+func IsTransient(err error) bool {
+	var transientErr *TransientError
+	return errors.As(err, &transientErr)
 }
 
 func IsAlreadyExists(err error) bool {

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package api
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -104,6 +105,18 @@ func TestHelperFunctions(t *testing.T) {
 			checkFn:  IsScopeError,
 			expected: false,
 		},
+		{
+			name:     "IsTransient with TransientError",
+			err:      &TransientError{StatusCode: 502},
+			checkFn:  IsTransient,
+			expected: true,
+		},
+		{
+			name:     "IsTransient with other error",
+			err:      &RateLimitError{},
+			checkFn:  IsTransient,
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -170,6 +183,21 @@ func TestErrorMessages(t *testing.T) {
 			name:    "ScopeError without required scope",
 			err:     &ScopeError{RequiredScope: ""},
 			wantMsg: "insufficient token scopes",
+		},
+		{
+			name:    "TransientError with status code",
+			err:     &TransientError{StatusCode: 503},
+			wantMsg: "transient API error (HTTP 503)",
+		},
+		{
+			name:    "TransientError with cause only",
+			err:     &TransientError{Cause: errors.New("connection reset")},
+			wantMsg: "transient API error: connection reset",
+		},
+		{
+			name:    "TransientError empty",
+			err:     &TransientError{},
+			wantMsg: "transient API error",
 		},
 	}
 

--- a/api/graphql.go
+++ b/api/graphql.go
@@ -24,6 +24,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 
@@ -311,6 +312,14 @@ func wrapGraphQLError(err error, resourceType ResourceType) error {
 		case code >= 500 && code < 600:
 			return &TransientError{StatusCode: code, Cause: err}
 		}
+	}
+
+	// Transport-level failures (timeout, connection reset, DNS) surface from
+	// shurcooL-graphql as the raw Go error, not an HTTPError or status-code
+	// string. Treat any net.Error as transient so the request is retried.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return &TransientError{Cause: err}
 	}
 
 	// Check for common GraphQL error patterns

--- a/api/graphql.go
+++ b/api/graphql.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package api
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -279,6 +280,18 @@ func (g *GraphQLAPI) DeleteLabel(label string, repo option.Repo) error {
 func wrapGraphQLError(err error, resourceType ResourceType) error {
 	if err == nil {
 		return nil
+	}
+
+	// Check for HTTP-level errors first (5xx, 429) so they map to typed errors
+	// regardless of response body.
+	var httpErr *api.HTTPError
+	if errors.As(err, &httpErr) {
+		switch {
+		case httpErr.StatusCode == 429:
+			return &RateLimitError{}
+		case httpErr.StatusCode >= 500 && httpErr.StatusCode < 600:
+			return &TransientError{StatusCode: httpErr.StatusCode, Cause: err}
+		}
 	}
 
 	errMsg := err.Error()

--- a/api/graphql.go
+++ b/api/graphql.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -76,13 +77,13 @@ func (g *GraphQLAPI) mutate(name string, m any, variables map[string]any, resour
 	}, g.retry)
 }
 
-// mutateNonIdempotent runs a non-idempotent GraphQL mutation. It retries only
-// on rate-limit errors, never on transient/network errors, because a retry
-// after a server-side commit could observe AlreadyExists/NotFound and report
-// a false failure.
+// mutateNonIdempotent runs a non-idempotent GraphQL mutation. Retrying on a
+// transient/network error could observe AlreadyExists/NotFound from a
+// previously-committed call and report a false failure, so this path retries
+// only on rate-limit errors (which are gateway-rejected before commit).
 func (g *GraphQLAPI) mutateNonIdempotent(name string, m any, variables map[string]any, resourceType ResourceType) error {
 	cfg := g.retry
-	cfg.retryable = isRateLimitOnly
+	cfg.retryable = IsRateLimit
 	return withRetry(func() error {
 		if err := g.client.Mutate(name, m, variables); err != nil {
 			return wrapGraphQLError(err, resourceType)
@@ -307,11 +308,8 @@ func wrapGraphQLError(err error, resourceType ResourceType) error {
 	// regardless of response body.
 	var httpErr *api.HTTPError
 	if errors.As(err, &httpErr) {
-		switch {
-		case httpErr.StatusCode == 429:
-			return &RateLimitError{}
-		case httpErr.StatusCode >= 500 && httpErr.StatusCode < 600:
-			return &TransientError{StatusCode: httpErr.StatusCode, Cause: err}
+		if mapped := statusToError(httpErr.StatusCode, err); mapped != nil {
+			return mapped
 		}
 	}
 
@@ -322,11 +320,8 @@ func wrapGraphQLError(err error, resourceType ResourceType) error {
 	// `non-200 OK status code: <code> <reason> body: "..."`. Recover the
 	// status code so 429/5xx still map to typed errors.
 	if code, ok := parseShurcoolStatusCode(errMsg); ok {
-		switch {
-		case code == 429:
-			return &RateLimitError{}
-		case code >= 500 && code < 600:
-			return &TransientError{StatusCode: code, Cause: err}
+		if mapped := statusToError(code, err); mapped != nil {
+			return mapped
 		}
 	}
 
@@ -377,11 +372,27 @@ func parseShurcoolStatusCode(msg string) (int, bool) {
 	if !ok {
 		return 0, false
 	}
-	var code int
-	if _, err := fmt.Sscanf(after, "%d", &code); err != nil {
+	fields := strings.Fields(after)
+	if len(fields) == 0 {
+		return 0, false
+	}
+	code, err := strconv.Atoi(fields[0])
+	if err != nil {
 		return 0, false
 	}
 	return code, true
+}
+
+// statusToError maps an HTTP status code to a typed retryable error, or nil if
+// the status is not retryable.
+func statusToError(code int, cause error) error {
+	switch {
+	case code == 429:
+		return &RateLimitError{}
+	case code >= 500 && code < 600:
+		return &TransientError{StatusCode: code, Cause: cause}
+	}
+	return nil
 }
 
 // escapeSearchQuery escapes special characters in a string for use in GitHub search queries.

--- a/api/graphql.go
+++ b/api/graphql.go
@@ -65,7 +65,8 @@ func (g *GraphQLAPI) query(name string, q any, variables map[string]any, resourc
 	}, g.retry)
 }
 
-// mutate runs a GraphQL mutation with automatic retry on rate limit and transient errors.
+// mutate runs an idempotent GraphQL mutation with automatic retry on rate
+// limit and transient errors.
 func (g *GraphQLAPI) mutate(name string, m any, variables map[string]any, resourceType ResourceType) error {
 	return withRetry(func() error {
 		if err := g.client.Mutate(name, m, variables); err != nil {
@@ -73,6 +74,21 @@ func (g *GraphQLAPI) mutate(name string, m any, variables map[string]any, resour
 		}
 		return nil
 	}, g.retry)
+}
+
+// mutateNonIdempotent runs a non-idempotent GraphQL mutation. It retries only
+// on rate-limit errors, never on transient/network errors, because a retry
+// after a server-side commit could observe AlreadyExists/NotFound and report
+// a false failure.
+func (g *GraphQLAPI) mutateNonIdempotent(name string, m any, variables map[string]any, resourceType ResourceType) error {
+	cfg := g.retry
+	cfg.retryable = isRateLimitOnly
+	return withRetry(func() error {
+		if err := g.client.Mutate(name, m, variables); err != nil {
+			return wrapGraphQLError(err, resourceType)
+		}
+		return nil
+	}, cfg)
 }
 
 // GetRepositoryID fetches the GraphQL node ID for a repository
@@ -218,7 +234,7 @@ func (g *GraphQLAPI) CreateLabel(label option.Label, repo option.Repo) error {
 		},
 	}
 
-	return g.mutate("CreateLabel", &mutation, variables, ResourceTypeLabel)
+	return g.mutateNonIdempotent("CreateLabel", &mutation, variables, ResourceTypeLabel)
 }
 
 // UpdateLabel updates an existing label in a repository
@@ -278,7 +294,7 @@ func (g *GraphQLAPI) DeleteLabel(label string, repo option.Repo) error {
 		},
 	}
 
-	return g.mutate("DeleteLabel", &mutation, variables, ResourceTypeLabel)
+	return g.mutateNonIdempotent("DeleteLabel", &mutation, variables, ResourceTypeLabel)
 }
 
 // wrapGraphQLError converts GraphQL API errors to custom error types

--- a/api/graphql.go
+++ b/api/graphql.go
@@ -38,6 +38,7 @@ type GraphQLAPI struct {
 	// Cache for repository IDs to avoid redundant queries
 	repoIDCache map[string]option.GraphQLID
 	repoIDMu    sync.RWMutex
+	retry       retryConfig
 }
 
 // NewGraphQLAPI creates a new GraphQL API client
@@ -49,7 +50,28 @@ func NewGraphQLAPI() (*GraphQLAPI, error) {
 	return &GraphQLAPI{
 		client:      client,
 		repoIDCache: make(map[string]option.GraphQLID),
+		retry:       defaultRetryConfig(),
 	}, nil
+}
+
+// query runs a GraphQL query with automatic retry on rate limit and transient errors.
+func (g *GraphQLAPI) query(name string, q any, variables map[string]any, resourceType ResourceType) error {
+	return withRetry(func() error {
+		if err := g.client.Query(name, q, variables); err != nil {
+			return wrapGraphQLError(err, resourceType)
+		}
+		return nil
+	}, g.retry)
+}
+
+// mutate runs a GraphQL mutation with automatic retry on rate limit and transient errors.
+func (g *GraphQLAPI) mutate(name string, m any, variables map[string]any, resourceType ResourceType) error {
+	return withRetry(func() error {
+		if err := g.client.Mutate(name, m, variables); err != nil {
+			return wrapGraphQLError(err, resourceType)
+		}
+		return nil
+	}, g.retry)
 }
 
 // GetRepositoryID fetches the GraphQL node ID for a repository
@@ -75,9 +97,8 @@ func (g *GraphQLAPI) GetRepositoryID(repo option.Repo) (option.GraphQLID, error)
 		"name":  graphql.String(repo.Repo),
 	}
 
-	err := g.client.Query("RepositoryID", &query, variables)
-	if err != nil {
-		return "", wrapGraphQLError(err, ResourceTypeRepository)
+	if err := g.query("RepositoryID", &query, variables, ResourceTypeRepository); err != nil {
+		return "", err
 	}
 
 	// Store in cache with write lock
@@ -104,9 +125,8 @@ func (g *GraphQLAPI) GetLabelID(repo option.Repo, labelName string) (option.Grap
 		"labelName": graphql.String(labelName),
 	}
 
-	err := g.client.Query("LabelID", &query, variables)
-	if err != nil {
-		return "", wrapGraphQLError(err, ResourceTypeLabel)
+	if err := g.query("LabelID", &query, variables, ResourceTypeLabel); err != nil {
+		return "", err
 	}
 
 	if query.Repository.Label.ID == "" {
@@ -144,9 +164,8 @@ func (g *GraphQLAPI) ListLabels(repo option.Repo) ([]option.Label, error) {
 			"cursor": cursor,
 		}
 
-		err := g.client.Query("RepositoryLabels", &query, variables)
-		if err != nil {
-			return nil, wrapGraphQLError(err, ResourceTypeRepository)
+		if err := g.query("RepositoryLabels", &query, variables, ResourceTypeRepository); err != nil {
+			return nil, err
 		}
 
 		for _, node := range query.Repository.Labels.Nodes {
@@ -198,12 +217,7 @@ func (g *GraphQLAPI) CreateLabel(label option.Label, repo option.Repo) error {
 		},
 	}
 
-	err = g.client.Mutate("CreateLabel", &mutation, variables)
-	if err != nil {
-		return wrapGraphQLError(err, ResourceTypeLabel)
-	}
-
-	return nil
+	return g.mutate("CreateLabel", &mutation, variables, ResourceTypeLabel)
 }
 
 // UpdateLabel updates an existing label in a repository
@@ -237,12 +251,7 @@ func (g *GraphQLAPI) UpdateLabel(label option.Label, repo option.Repo) error {
 		},
 	}
 
-	err = g.client.Mutate("UpdateLabel", &mutation, variables)
-	if err != nil {
-		return wrapGraphQLError(err, ResourceTypeLabel)
-	}
-
-	return nil
+	return g.mutate("UpdateLabel", &mutation, variables, ResourceTypeLabel)
 }
 
 // DeleteLabel deletes a label from a repository
@@ -268,12 +277,7 @@ func (g *GraphQLAPI) DeleteLabel(label string, repo option.Repo) error {
 		},
 	}
 
-	err = g.client.Mutate("DeleteLabel", &mutation, variables)
-	if err != nil {
-		return wrapGraphQLError(err, ResourceTypeLabel)
-	}
-
-	return nil
+	return g.mutate("DeleteLabel", &mutation, variables, ResourceTypeLabel)
 }
 
 // wrapGraphQLError converts GraphQL API errors to custom error types
@@ -295,6 +299,19 @@ func wrapGraphQLError(err error, resourceType ResourceType) error {
 	}
 
 	errMsg := err.Error()
+
+	// shurcooL-graphql (used by go-gh's Query/Mutate) does not preserve
+	// HTTPError on non-2xx responses; it returns a plain error of the form
+	// `non-200 OK status code: <code> <reason> body: "..."`. Recover the
+	// status code so 429/5xx still map to typed errors.
+	if code, ok := parseShurcoolStatusCode(errMsg); ok {
+		switch {
+		case code == 429:
+			return &RateLimitError{}
+		case code >= 500 && code < 600:
+			return &TransientError{StatusCode: code, Cause: err}
+		}
+	}
 
 	// Check for common GraphQL error patterns
 	if strings.Contains(errMsg, "Could not resolve to a Repository") {
@@ -326,6 +343,20 @@ func wrapGraphQLError(err error, resourceType ResourceType) error {
 	}
 
 	return fmt.Errorf("GraphQL API error: %s", errMsg)
+}
+
+// parseShurcoolStatusCode extracts the HTTP status code from a shurcooL-graphql
+// non-200 error message. Returns (0, false) if the message does not match.
+func parseShurcoolStatusCode(msg string) (int, bool) {
+	_, after, ok := strings.Cut(msg, "non-200 OK status code: ")
+	if !ok {
+		return 0, false
+	}
+	var code int
+	if _, err := fmt.Sscanf(after, "%d", &code); err != nil {
+		return 0, false
+	}
+	return code, true
 }
 
 // escapeSearchQuery escapes special characters in a string for use in GitHub search queries.
@@ -382,9 +413,8 @@ func (g *GraphQLAPI) searchIssuesAndPRs(repo option.Repo, labelName string) ([]o
 			"cursor": cursor,
 		}
 
-		err := g.client.Query("SearchIssuesAndPRs", &query, variables)
-		if err != nil {
-			return nil, wrapGraphQLError(err, ResourceTypeRepository)
+		if err := g.query("SearchIssuesAndPRs", &query, variables, ResourceTypeRepository); err != nil {
+			return nil, err
 		}
 
 		for _, node := range query.Search.Nodes {
@@ -453,22 +483,14 @@ func (g *GraphQLAPI) searchDiscussions(repo option.Repo, labelName string) ([]op
 			"cursor": cursor,
 		}
 
-		err := g.client.Query("SearchDiscussions", &query, variables)
-		if err != nil {
+		if err := g.query("SearchDiscussions", &query, variables, ResourceTypeRepository); err != nil {
+			// Treat "discussions disabled" as an empty result rather than an error.
 			errMsg := err.Error()
-			// Check for explicit errors first
-			if strings.Contains(errMsg, "Could not resolve to a Repository") {
-				return nil, wrapGraphQLError(err, ResourceTypeRepository)
-			}
-			if strings.Contains(errMsg, "FORBIDDEN") || strings.Contains(errMsg, "don't have permission") {
-				return nil, wrapGraphQLError(err, ResourceTypeRepository)
-			}
-			// If discussions are not enabled/supported, just return empty
 			if strings.Contains(errMsg, "does not have discussions enabled") ||
 				strings.Contains(errMsg, "Discussions are disabled") {
 				return allLabelables, nil
 			}
-			return nil, wrapGraphQLError(err, ResourceTypeRepository)
+			return nil, err
 		}
 
 		for _, node := range query.Search.Nodes {
@@ -524,12 +546,7 @@ func (g *GraphQLAPI) AddLabelsToLabelable(labelableID option.GraphQLID, labelIDs
 		},
 	}
 
-	err := g.client.Mutate("AddLabelsToLabelable", &mutation, variables)
-	if err != nil {
-		return wrapGraphQLError(err, ResourceTypeLabel)
-	}
-
-	return nil
+	return g.mutate("AddLabelsToLabelable", &mutation, variables, ResourceTypeLabel)
 }
 
 // RemoveLabelsFromLabelable removes labels from a labelable resource (issue, PR, or discussion)
@@ -558,10 +575,5 @@ func (g *GraphQLAPI) RemoveLabelsFromLabelable(labelableID option.GraphQLID, lab
 		},
 	}
 
-	err := g.client.Mutate("RemoveLabelsFromLabelable", &mutation, variables)
-	if err != nil {
-		return wrapGraphQLError(err, ResourceTypeLabel)
-	}
-
-	return nil
+	return g.mutate("RemoveLabelsFromLabelable", &mutation, variables, ResourceTypeLabel)
 }

--- a/api/graphql_test.go
+++ b/api/graphql_test.go
@@ -22,7 +22,11 @@ THE SOFTWARE.
 package api
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -1471,6 +1475,42 @@ func TestEscapeSearchQuery(t *testing.T) {
 	}
 }
 
+func TestWrapGraphQLError_NetworkError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "url.Error wrapping connection refused",
+			err: &url.Error{
+				Op:  "Post",
+				URL: "https://api.github.com/graphql",
+				Err: &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			},
+		},
+		{
+			name: "DNS error",
+			err:  &net.DNSError{Err: "no such host", Name: "api.github.com"},
+		},
+		{
+			name: "context deadline wrapped in url.Error",
+			err: &url.Error{
+				Op:  "Post",
+				URL: "https://api.github.com/graphql",
+				Err: context.DeadlineExceeded,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapGraphQLError(tt.err, ResourceTypeRepository)
+			if !IsTransient(got) {
+				t.Errorf("wrapGraphQLError(%v) = %v, want TransientError", tt.err, got)
+			}
+		})
+	}
+}
+
 func TestGraphQLAPI_RetryOnTransient(t *testing.T) {
 	defer gock.Off()
 
@@ -1504,6 +1544,42 @@ func TestGraphQLAPI_RetryOnTransient(t *testing.T) {
 	}
 	if !gock.IsDone() {
 		t.Errorf("pending mocks: %d (retry should consume all responses)", len(gock.Pending()))
+	}
+}
+
+func TestGraphQLAPI_RetryOnNetworkError(t *testing.T) {
+	defer gock.Off()
+
+	// First two calls fail at the transport layer; third succeeds. The
+	// transport error is wrapped in *url.Error by net/http, which satisfies
+	// net.Error and is therefore classified as transient.
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		ReplyError(errors.New("connection reset by peer"))
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		ReplyError(errors.New("connection reset by peer"))
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"id": "R_recovered",
+				},
+			},
+		})
+
+	g := newTestGraphQLAPI(t)
+	got, err := g.GetRepositoryID(option.Repo{Owner: "owner", Repo: "repo"})
+	if err != nil {
+		t.Fatalf("GetRepositoryID() error = %v, want nil after retries", err)
+	}
+	if got != "R_recovered" {
+		t.Errorf("GetRepositoryID() = %v, want R_recovered", got)
+	}
+	if !gock.IsDone() {
+		t.Errorf("pending mocks: %d, want 0", len(gock.Pending()))
 	}
 }
 

--- a/api/graphql_test.go
+++ b/api/graphql_test.go
@@ -1606,6 +1606,108 @@ func TestGraphQLAPI_RetryGivesUpAfterMaxAttempts(t *testing.T) {
 	}
 }
 
+func TestGraphQLAPI_CreateLabel_NoRetryOnTransient(t *testing.T) {
+	defer gock.Off()
+
+	// GetRepositoryID succeeds (queries retry on transient, but we return 200 here).
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{"id": "R_1"},
+			},
+		})
+	// CreateLabel mutation returns 503 — must NOT be retried (non-idempotent).
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(503).
+		BodyString("service unavailable")
+
+	g := newTestGraphQLAPI(t)
+	err := g.CreateLabel(option.Label{Name: "bug", Color: "d73a4a"}, option.Repo{Owner: "owner", Repo: "repo"})
+	if err == nil {
+		t.Fatal("CreateLabel() error = nil, want transient error")
+	}
+	if !IsTransient(err) {
+		t.Errorf("CreateLabel() error = %v, want TransientError", err)
+	}
+	if !gock.IsDone() {
+		t.Errorf("pending mocks: %d, want 0 (mutation must not retry on transient)", len(gock.Pending()))
+	}
+}
+
+func TestGraphQLAPI_CreateLabel_RetriesOnRateLimit(t *testing.T) {
+	defer gock.Off()
+
+	// GetRepositoryID succeeds.
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{"id": "R_1"},
+			},
+		})
+	// CreateLabel: rate-limited once, then succeeds.
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(429).
+		BodyString("rate limited")
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"createLabel": map[string]any{
+					"label": map[string]any{"id": "LA_1"},
+				},
+			},
+		})
+
+	g := newTestGraphQLAPI(t)
+	err := g.CreateLabel(option.Label{Name: "bug", Color: "d73a4a"}, option.Repo{Owner: "owner", Repo: "repo"})
+	if err != nil {
+		t.Fatalf("CreateLabel() error = %v, want nil after rate-limit retry", err)
+	}
+	if !gock.IsDone() {
+		t.Errorf("pending mocks: %d, want 0", len(gock.Pending()))
+	}
+}
+
+func TestGraphQLAPI_DeleteLabel_NoRetryOnTransient(t *testing.T) {
+	defer gock.Off()
+
+	// GetLabelID succeeds.
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"label": map[string]any{"id": "LA_1"},
+				},
+			},
+		})
+	// DeleteLabel mutation returns 503 — must NOT be retried.
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(503).
+		BodyString("service unavailable")
+
+	g := newTestGraphQLAPI(t)
+	err := g.DeleteLabel("bug", option.Repo{Owner: "owner", Repo: "repo"})
+	if err == nil {
+		t.Fatal("DeleteLabel() error = nil, want transient error")
+	}
+	if !IsTransient(err) {
+		t.Errorf("DeleteLabel() error = %v, want TransientError", err)
+	}
+	if !gock.IsDone() {
+		t.Errorf("pending mocks: %d, want 0 (mutation must not retry on transient)", len(gock.Pending()))
+	}
+}
+
 func TestGraphQLAPI_NoRetryOnNonRetryable(t *testing.T) {
 	defer gock.Off()
 

--- a/api/graphql_test.go
+++ b/api/graphql_test.go
@@ -24,6 +24,7 @@ package api
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/h2non/gock"
@@ -42,6 +43,12 @@ func newTestGraphQLAPI(t *testing.T) *GraphQLAPI {
 	return &GraphQLAPI{
 		client:      client,
 		repoIDCache: make(map[string]option.GraphQLID),
+		retry: retryConfig{
+			maxAttempts: 3,
+			baseDelay:   0,
+			maxDelay:    0,
+			sleep:       func(time.Duration) {},
+		},
 	}
 }
 
@@ -1461,5 +1468,96 @@ func TestEscapeSearchQuery(t *testing.T) {
 				t.Errorf("escapeSearchQuery(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGraphQLAPI_RetryOnTransient(t *testing.T) {
+	defer gock.Off()
+
+	// First two calls return 503, third succeeds.
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(503).
+		BodyString("service unavailable")
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(503).
+		BodyString("service unavailable")
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"id": "R_retry",
+				},
+			},
+		})
+
+	g := newTestGraphQLAPI(t)
+	got, err := g.GetRepositoryID(option.Repo{Owner: "owner", Repo: "repo"})
+	if err != nil {
+		t.Fatalf("GetRepositoryID() error = %v, want nil after retries", err)
+	}
+	if got != "R_retry" {
+		t.Errorf("GetRepositoryID() = %v, want R_retry", got)
+	}
+	if !gock.IsDone() {
+		t.Errorf("pending mocks: %d (retry should consume all responses)", len(gock.Pending()))
+	}
+}
+
+func TestGraphQLAPI_RetryGivesUpAfterMaxAttempts(t *testing.T) {
+	defer gock.Off()
+
+	for range 3 {
+		gock.New("https://api.github.com").
+			Post("/graphql").
+			Reply(503).
+			BodyString("service unavailable")
+	}
+
+	g := newTestGraphQLAPI(t)
+	_, err := g.GetRepositoryID(option.Repo{Owner: "owner", Repo: "repo"})
+	if err == nil {
+		t.Fatal("GetRepositoryID() error = nil, want transient error")
+	}
+	if !IsTransient(err) {
+		t.Errorf("GetRepositoryID() error = %v, want TransientError", err)
+	}
+	if !gock.IsDone() {
+		t.Errorf("pending mocks: %d, want 0", len(gock.Pending()))
+	}
+}
+
+func TestGraphQLAPI_NoRetryOnNonRetryable(t *testing.T) {
+	defer gock.Off()
+
+	// Single 404 response — must not be retried.
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"repository": nil,
+			},
+			"errors": []map[string]any{
+				{
+					"type":    "NOT_FOUND",
+					"message": "Could not resolve to a Repository with the name 'nonexistent'.",
+				},
+			},
+		})
+
+	g := newTestGraphQLAPI(t)
+	_, err := g.GetRepositoryID(option.Repo{Owner: "owner", Repo: "nonexistent"})
+	if err == nil {
+		t.Fatal("GetRepositoryID() error = nil, want NotFoundError")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("GetRepositoryID() error = %v, want NotFoundError", err)
+	}
+	if !gock.IsDone() {
+		t.Errorf("pending mocks: %d, want 0 (no retry expected)", len(gock.Pending()))
 	}
 }

--- a/api/graphql_test.go
+++ b/api/graphql_test.go
@@ -52,6 +52,7 @@ func newTestGraphQLAPI(t *testing.T) *GraphQLAPI {
 			baseDelay:   0,
 			maxDelay:    0,
 			sleep:       func(time.Duration) {},
+			retryable:   isRetryable,
 		},
 	}
 }

--- a/api/retry.go
+++ b/api/retry.go
@@ -29,6 +29,9 @@ type retryConfig struct {
 	baseDelay   time.Duration
 	maxDelay    time.Duration
 	sleep       func(time.Duration)
+	// retryable returns true for errors that should be retried. If nil,
+	// isRetryable is used (rate limit + transient).
+	retryable func(error) bool
 }
 
 func defaultRetryConfig() retryConfig {
@@ -43,6 +46,10 @@ func defaultRetryConfig() retryConfig {
 // withRetry runs fn and retries on retryable errors using exponential backoff.
 // It returns the last error if all attempts fail or fn returns a non-retryable error.
 func withRetry(fn func() error, cfg retryConfig) error {
+	predicate := cfg.retryable
+	if predicate == nil {
+		predicate = isRetryable
+	}
 	var err error
 	delay := cfg.baseDelay
 	for attempt := 1; attempt <= cfg.maxAttempts; attempt++ {
@@ -50,7 +57,7 @@ func withRetry(fn func() error, cfg retryConfig) error {
 		if err == nil {
 			return nil
 		}
-		if !isRetryable(err) || attempt == cfg.maxAttempts {
+		if !predicate(err) || attempt == cfg.maxAttempts {
 			return err
 		}
 		cfg.sleep(delay)
@@ -66,4 +73,13 @@ func withRetry(fn func() error, cfg retryConfig) error {
 // and transient (5xx, network) failures.
 func isRetryable(err error) bool {
 	return IsRateLimit(err) || IsTransient(err)
+}
+
+// isRateLimitOnly returns true only for rate-limit errors. Used for non-idempotent
+// mutations (createLabel, deleteLabel) where retrying a transient/network error
+// could observe the side effect of a previously-committed call (AlreadyExists /
+// NotFound) and report a false failure. Rate-limit retries are safe because the
+// gateway rejects the request before it reaches the data layer.
+func isRateLimitOnly(err error) bool {
+	return IsRateLimit(err)
 }

--- a/api/retry.go
+++ b/api/retry.go
@@ -40,16 +40,13 @@ func defaultRetryConfig() retryConfig {
 		baseDelay:   1 * time.Second,
 		maxDelay:    8 * time.Second,
 		sleep:       time.Sleep,
+		retryable:   isRetryable,
 	}
 }
 
 // withRetry runs fn and retries on retryable errors using exponential backoff.
 // It returns the last error if all attempts fail or fn returns a non-retryable error.
 func withRetry(fn func() error, cfg retryConfig) error {
-	predicate := cfg.retryable
-	if predicate == nil {
-		predicate = isRetryable
-	}
 	var err error
 	delay := cfg.baseDelay
 	for attempt := 1; attempt <= cfg.maxAttempts; attempt++ {
@@ -57,7 +54,7 @@ func withRetry(fn func() error, cfg retryConfig) error {
 		if err == nil {
 			return nil
 		}
-		if !predicate(err) || attempt == cfg.maxAttempts {
+		if !cfg.retryable(err) || attempt == cfg.maxAttempts {
 			return err
 		}
 		cfg.sleep(delay)
@@ -73,13 +70,4 @@ func withRetry(fn func() error, cfg retryConfig) error {
 // and transient (5xx, network) failures.
 func isRetryable(err error) bool {
 	return IsRateLimit(err) || IsTransient(err)
-}
-
-// isRateLimitOnly returns true only for rate-limit errors. Used for non-idempotent
-// mutations (createLabel, deleteLabel) where retrying a transient/network error
-// could observe the side effect of a previously-committed call (AlreadyExists /
-// NotFound) and report a false failure. Rate-limit retries are safe because the
-// gateway rejects the request before it reaches the data layer.
-func isRateLimitOnly(err error) bool {
-	return IsRateLimit(err)
 }

--- a/api/retry.go
+++ b/api/retry.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package api
+
+import "time"
+
+// retryConfig controls the behavior of withRetry.
+type retryConfig struct {
+	maxAttempts int
+	baseDelay   time.Duration
+	maxDelay    time.Duration
+	sleep       func(time.Duration)
+}
+
+func defaultRetryConfig() retryConfig {
+	return retryConfig{
+		maxAttempts: 3,
+		baseDelay:   1 * time.Second,
+		maxDelay:    8 * time.Second,
+		sleep:       time.Sleep,
+	}
+}
+
+// withRetry runs fn and retries on retryable errors using exponential backoff.
+// It returns the last error if all attempts fail or fn returns a non-retryable error.
+func withRetry(fn func() error, cfg retryConfig) error {
+	var err error
+	delay := cfg.baseDelay
+	for attempt := 1; attempt <= cfg.maxAttempts; attempt++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		if !isRetryable(err) || attempt == cfg.maxAttempts {
+			return err
+		}
+		cfg.sleep(delay)
+		delay *= 2
+		if delay > cfg.maxDelay {
+			delay = cfg.maxDelay
+		}
+	}
+	return err
+}
+
+// isRetryable returns true for errors that may succeed on retry: rate limits
+// and transient (5xx, network) failures.
+func isRetryable(err error) bool {
+	return IsRateLimit(err) || IsTransient(err)
+}

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -159,6 +159,50 @@ func TestWithRetry_BackoffCappedByMaxDelay(t *testing.T) {
 	}
 }
 
+func TestWithRetry_CustomRetryablePredicate(t *testing.T) {
+	cfg, sleeps := testRetryConfig()
+	cfg.retryable = isRateLimitOnly
+	calls := 0
+
+	// TransientError is normally retryable but the custom predicate excludes
+	// it; the call should run exactly once.
+	err := withRetry(func() error {
+		calls++
+		return &TransientError{StatusCode: 503}
+	}, cfg)
+
+	if !IsTransient(err) {
+		t.Errorf("withRetry() error = %v, want TransientError", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (transient must not retry under rate-limit-only predicate)", calls)
+	}
+	if len(*sleeps) != 0 {
+		t.Errorf("sleeps = %v, want none", *sleeps)
+	}
+}
+
+func TestWithRetry_RateLimitOnlyStillRetriesRateLimit(t *testing.T) {
+	cfg, _ := testRetryConfig()
+	cfg.retryable = isRateLimitOnly
+	calls := 0
+
+	err := withRetry(func() error {
+		calls++
+		if calls < 2 {
+			return &RateLimitError{}
+		}
+		return nil
+	}, cfg)
+
+	if err != nil {
+		t.Errorf("withRetry() error = %v, want nil", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+}
+
 func TestIsRetryable(t *testing.T) {
 	tests := []struct {
 		name string

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -34,6 +34,7 @@ func testRetryConfig() (retryConfig, *[]time.Duration) {
 		baseDelay:   10 * time.Millisecond,
 		maxDelay:    40 * time.Millisecond,
 		sleep:       func(d time.Duration) { sleeps = append(sleeps, d) },
+		retryable:   isRetryable,
 	}
 	return cfg, &sleeps
 }
@@ -137,6 +138,7 @@ func TestWithRetry_BackoffCappedByMaxDelay(t *testing.T) {
 		baseDelay:   10 * time.Millisecond,
 		maxDelay:    25 * time.Millisecond,
 		sleep:       func(d time.Duration) { sleeps = append(sleeps, d) },
+		retryable:   isRetryable,
 	}
 
 	_ = withRetry(func() error {
@@ -161,7 +163,7 @@ func TestWithRetry_BackoffCappedByMaxDelay(t *testing.T) {
 
 func TestWithRetry_CustomRetryablePredicate(t *testing.T) {
 	cfg, sleeps := testRetryConfig()
-	cfg.retryable = isRateLimitOnly
+	cfg.retryable = IsRateLimit
 	calls := 0
 
 	// TransientError is normally retryable but the custom predicate excludes
@@ -184,7 +186,7 @@ func TestWithRetry_CustomRetryablePredicate(t *testing.T) {
 
 func TestWithRetry_RateLimitOnlyStillRetriesRateLimit(t *testing.T) {
 	cfg, _ := testRetryConfig()
-	cfg.retryable = isRateLimitOnly
+	cfg.retryable = IsRateLimit
 	calls := 0
 
 	err := withRetry(func() error {

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright © 2025 Takayuki Nagatomi <tnagatomi@okweird.net>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func testRetryConfig() (retryConfig, *[]time.Duration) {
+	var sleeps []time.Duration
+	cfg := retryConfig{
+		maxAttempts: 3,
+		baseDelay:   10 * time.Millisecond,
+		maxDelay:    40 * time.Millisecond,
+		sleep:       func(d time.Duration) { sleeps = append(sleeps, d) },
+	}
+	return cfg, &sleeps
+}
+
+func TestWithRetry_SuccessOnFirstAttempt(t *testing.T) {
+	cfg, sleeps := testRetryConfig()
+	calls := 0
+
+	err := withRetry(func() error {
+		calls++
+		return nil
+	}, cfg)
+
+	if err != nil {
+		t.Fatalf("withRetry() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+	if len(*sleeps) != 0 {
+		t.Errorf("sleeps = %v, want none", *sleeps)
+	}
+}
+
+func TestWithRetry_RetryableThenSuccess(t *testing.T) {
+	cfg, sleeps := testRetryConfig()
+	calls := 0
+
+	err := withRetry(func() error {
+		calls++
+		if calls < 3 {
+			return &TransientError{StatusCode: 502}
+		}
+		return nil
+	}, cfg)
+
+	if err != nil {
+		t.Fatalf("withRetry() error = %v, want nil", err)
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+	wantSleeps := []time.Duration{10 * time.Millisecond, 20 * time.Millisecond}
+	if len(*sleeps) != len(wantSleeps) {
+		t.Fatalf("sleeps = %v, want %v", *sleeps, wantSleeps)
+	}
+	for i, d := range *sleeps {
+		if d != wantSleeps[i] {
+			t.Errorf("sleeps[%d] = %v, want %v", i, d, wantSleeps[i])
+		}
+	}
+}
+
+func TestWithRetry_NonRetryableErrorStops(t *testing.T) {
+	cfg, sleeps := testRetryConfig()
+	calls := 0
+	wantErr := &NotFoundError{ResourceType: ResourceTypeRepository}
+
+	err := withRetry(func() error {
+		calls++
+		return wantErr
+	}, cfg)
+
+	if !errors.Is(err, wantErr) {
+		t.Errorf("withRetry() error = %v, want %v", err, wantErr)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (non-retryable should not retry)", calls)
+	}
+	if len(*sleeps) != 0 {
+		t.Errorf("sleeps = %v, want none", *sleeps)
+	}
+}
+
+func TestWithRetry_AllAttemptsFail(t *testing.T) {
+	cfg, sleeps := testRetryConfig()
+	calls := 0
+	wantErr := &RateLimitError{}
+
+	err := withRetry(func() error {
+		calls++
+		return wantErr
+	}, cfg)
+
+	if !errors.Is(err, wantErr) {
+		t.Errorf("withRetry() error = %v, want %v", err, wantErr)
+	}
+	if calls != cfg.maxAttempts {
+		t.Errorf("calls = %d, want %d", calls, cfg.maxAttempts)
+	}
+	// Sleeps happen between attempts, so maxAttempts-1 sleeps total.
+	if len(*sleeps) != cfg.maxAttempts-1 {
+		t.Errorf("len(sleeps) = %d, want %d", len(*sleeps), cfg.maxAttempts-1)
+	}
+}
+
+func TestWithRetry_BackoffCappedByMaxDelay(t *testing.T) {
+	var sleeps []time.Duration
+	cfg := retryConfig{
+		maxAttempts: 5,
+		baseDelay:   10 * time.Millisecond,
+		maxDelay:    25 * time.Millisecond,
+		sleep:       func(d time.Duration) { sleeps = append(sleeps, d) },
+	}
+
+	_ = withRetry(func() error {
+		return &TransientError{StatusCode: 503}
+	}, cfg)
+
+	want := []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		25 * time.Millisecond,
+		25 * time.Millisecond,
+	}
+	if len(sleeps) != len(want) {
+		t.Fatalf("sleeps = %v, want %v", sleeps, want)
+	}
+	for i, d := range sleeps {
+		if d != want[i] {
+			t.Errorf("sleeps[%d] = %v, want %v", i, d, want[i])
+		}
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"RateLimitError", &RateLimitError{}, true},
+		{"TransientError", &TransientError{StatusCode: 502}, true},
+		{"NotFoundError", &NotFoundError{ResourceType: ResourceTypeRepository}, false},
+		{"ForbiddenError", &ForbiddenError{}, false},
+		{"plain error", errors.New("oops"), false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `TransientError` type and detect HTTP 429/5xx responses (including the plain error returned by shurcooL-graphql) as typed errors
- Add `withRetry` helper with exponential backoff (3 attempts, 1s base, 8s cap) and an injectable sleep for tests
- Wrap every GraphQL `Query`/`Mutate` call so operations across many repositories survive intermittent rate limits and transient API failures

Closes #68

## Test plan

- [x] `go test ./...`
- [x] New unit tests cover backoff sequence, retryable vs. non-retryable errors, max-attempts behavior
- [x] gock-based integration tests verify retry succeeds on 503→503→200 and gives up after 3×503
- [x] gock-based test verifies non-retryable errors (404) do not retry