### PR TITLE
feat: add --version flag

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,40 +22,24 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/spf13/cobra"
+	"bytes"
+	"strings"
+	"testing"
 )
 
-var (
-	repos    string
-	dryRun   bool
-	labels   string
-	jsonPath string
-	yamlPath string
-)
+func TestVersionFlag(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"--version"})
+	rootCmd.Version = "test-version"
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:           "gh-fuda",
-	Short:         "gh extension for manipulating labels across multiple repositories",
-	SilenceErrors: true,
-	SilenceUsage:  true,
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute(version string) {
-	rootCmd.Version = version
-	cobra.CheckErr(rootCmd.Execute())
-}
-
-func init() {
-	rootCmd.PersistentFlags().StringVarP(&repos, "repos", "R", "", "Select repositories using the OWNER/REPO format separated by comma (e.g., owner1/repo1,owner2/repo2)")
-	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Dry run")
-
-	err := rootCmd.MarkPersistentFlagRequired("repos")
+	err := rootCmd.Execute()
 	if err != nil {
-		fmt.Printf("Failed to mark flag required: %v\n", err)
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "test-version") {
+		t.Errorf("expected version output to contain 'test-version', got %q", output)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -23,6 +23,10 @@ package main
 
 import "github.com/tnagatomi/gh-fuda/cmd"
 
+// version is set at build time via ldflags.
+// Example: go build -ldflags "-X main.version=v1.0.0"
+var version = "dev"
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
## Summary
Add `--version` flag to display the installed extension version.

## Motivation
Closes #76. Users want to check which version of gh-fuda they have installed.

## Changes
- Added `version` variable in `main.go` (set via ldflags at build time)
- Modified `cmd.Execute()` to accept and set the version on the root command
- Added `TestVersionFlag` test in `cmd/root_test.go`

## Verification
```bash
# Build with version
go build -ldflags "-X main.version=v1.0.0" -o gh-fuda
./gh-fuda --version
# Output: gh-fuda version v1.0.0

# Run tests
go test ./...
```

Note: The version is injected at build time via `-ldflags "-X main.version=<tag>"` from the `gh-extension-precompile` release workflow.