### PR TITLE
feat: add --version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: cli/gh-extension-precompile@v2
         with:
           go_version_file: go.mod
+          go_build_options: "-ldflags=-s -w -X github.com/tnagatomi/gh-fuda/cmd.version=${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Login to GitHub with `gh auth login` (ref. [gh manual of gh auth login](https://
 
 - `-R`, `--repos`: Select repositories using the `OWNER/REPO` format separated by comma (e.g., `owner1/repo1,owner2/repo1`)
 - `--dry-run`: Check what operations would be executed without actually operating on the repositories
+- `-v`, `--version`: Print the installed extension version and exit
 
 ### List of Commands
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,43 +22,28 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/spf13/cobra"
+	"bytes"
+	"strings"
+	"testing"
 )
 
-var (
-	repos    string
-	dryRun   bool
-	labels   string
-	jsonPath string
-	yamlPath string
-)
+func TestRootCmd_VersionFlag(t *testing.T) {
+	repos = ""
 
-// version is set via -ldflags during release builds.
-var version = "dev"
+	var out bytes.Buffer
+	rootCmd.SetArgs([]string{"--version"})
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:           "gh-fuda",
-	Short:         "gh extension for manipulating labels across multiple repositories",
-	Version:       version,
-	SilenceErrors: true,
-	SilenceUsage:  true,
-}
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	cobra.CheckErr(rootCmd.Execute())
-}
-
-func init() {
-	rootCmd.PersistentFlags().StringVarP(&repos, "repos", "R", "", "Select repositories using the OWNER/REPO format separated by comma (e.g., owner1/repo1,owner2/repo2)")
-	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Dry run")
-
-	err := rootCmd.MarkPersistentFlagRequired("repos")
-	if err != nil {
-		fmt.Printf("Failed to mark flag required: %v\n", err)
+	got := out.String()
+	if !strings.Contains(got, "gh-fuda version") {
+		t.Errorf("output = %q, want it to contain %q", got, "gh-fuda version")
+	}
+	if !strings.Contains(got, version) {
+		t.Errorf("output = %q, want it to contain version %q", got, version)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `--version` to the root command using Cobra's built-in support.
- Inject the version at release time via `-ldflags -X .../cmd.version=${tag}`; defaults to `dev` locally.

Closes #76