### PR TITLE
fix: release workflow fails to build due to ldflags space split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: cli/gh-extension-precompile@v2
         with:
           go_version_file: go.mod
-          go_build_options: "-ldflags=-s -w -X github.com/tnagatomi/gh-fuda/cmd.version=${{ github.ref_name }}"
+          go_build_options: -ldflags=-X=github.com/tnagatomi/gh-fuda/cmd.version=${{ github.ref_name }}


### PR DESCRIPTION
## Summary
`cli/gh-extension-precompile@v2` expands `GO_BUILD_OPTIONS` unquoted, so the previous `"-ldflags=-s -w -X ..."` value was split on spaces and `-w` reached `go build` as an undefined flag, breaking the v3.2.0 release. Switch to the single-token `-ldflags=-X=...` form (the same pattern used by [github/gh-stack](https://github.com/github/gh-stack/blob/main/.github/workflows/release.yml)).

`-s` / `-w` are dropped: they cannot coexist with `-X` in one space-free token. Binary grows by ~3 MB (7 MB → 10 MB on darwin/arm64), with no functional or security impact for an OSS CLI built with `-trimpath`.

## Test plan
- [ ] After merge, retag and confirm the release workflow succeeds and the published binary reports the injected version