### PR TITLE
feat: preserve labels during empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,13 @@ Delete all labels from the specified repositories.
 ##### Options
 
 - `-y`, `--yes`: Do not prompt for confirmation
+- `--exclude`: Comma-separated label names to keep
 
 ##### Example
 
 ```bash
 gh fuda empty -R "owner1/repo1,owner1/repo2,owner2/repo1"
+gh fuda empty -R "owner1/repo1" --exclude "good first issue,help wanted"
 ```
 
 #### Merge Labels

--- a/cmd/empty.go
+++ b/cmd/empty.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/tnagatomi/gh-fuda/executor"
@@ -33,6 +34,7 @@ import (
 func NewEmptyCmd() *cobra.Command {
 	var skipConfirm bool
 	var forceDeprecated bool
+	var exclude string
 
 	var emptyCmd = &cobra.Command{
 		Use:   "empty",
@@ -41,6 +43,11 @@ func NewEmptyCmd() *cobra.Command {
 			repoList, err := parser.Repo(repos)
 			if err != nil {
 				return fmt.Errorf("failed to parse repos option: %v", err)
+			}
+
+			excludeLabels, err := parseExcludeLabels(exclude)
+			if err != nil {
+				return fmt.Errorf("failed to parse exclude option: %v", err)
 			}
 
 			in := cmd.InOrStdin()
@@ -62,7 +69,7 @@ func NewEmptyCmd() *cobra.Command {
 				return fmt.Errorf("failed to create executor: %v", err)
 			}
 
-			err = e.Empty(out, repoList)
+			err = e.Empty(out, repoList, excludeLabels)
 			if err != nil {
 				return fmt.Errorf("failed to empty labels: %v", err)
 			}
@@ -73,9 +80,27 @@ func NewEmptyCmd() *cobra.Command {
 
 	emptyCmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Do not prompt for confirmation")
 	emptyCmd.Flags().BoolVar(&forceDeprecated, "force", false, "Do not prompt for confirmation")
+	emptyCmd.Flags().StringVar(&exclude, "exclude", "", "Comma-separated label names to keep")
 	_ = emptyCmd.Flags().MarkDeprecated("force", "use -y/--yes instead")
 
 	return emptyCmd
+}
+
+func parseExcludeLabels(input string) ([]string, error) {
+	if input == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(input, ",")
+	labels := make([]string, 0, len(parts))
+	for _, part := range parts {
+		label := strings.TrimSpace(part)
+		if label == "" {
+			return nil, fmt.Errorf("label name cannot be empty")
+		}
+		labels = append(labels, label)
+	}
+	return labels, nil
 }
 
 func init() {

--- a/cmd/empty_test.go
+++ b/cmd/empty_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseExcludeLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		want        []string
+		errContains string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "comma separated labels",
+			input: "good first issue, help wanted",
+			want:  []string{"good first issue", "help wanted"},
+		},
+		{
+			name:  "keeps colons in label names",
+			input: "type: bug, priority: high",
+			want:  []string{"type: bug", "priority: high"},
+		},
+		{
+			name:        "rejects empty label name",
+			input:       "bug,,help wanted",
+			errContains: "label name cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExcludeLabels(tt.input)
+			if tt.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("parseExcludeLabels() error = %v, want containing %q", err, tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseExcludeLabels() unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseExcludeLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -422,17 +422,19 @@ func (e *Executor) listLabelsForRepo(repo option.Repo) *JobResult {
 }
 
 // Empty empties labels across multiple repositories
-func (e *Executor) Empty(out io.Writer, repos []option.Repo) error {
+func (e *Executor) Empty(out io.Writer, repos []option.Repo, excludeLabels []string) error {
+	excludeSet := labelSet(excludeLabels)
+
 	// Dry-run mode: execute sequentially with immediate output
 	if e.dryRun {
-		return e.emptyDryRun(out, repos)
+		return e.emptyDryRun(out, repos, excludeSet)
 	}
 
 	// Normal mode: execute in parallel
-	return e.emptyParallel(out, repos)
+	return e.emptyParallel(out, repos, excludeSet)
 }
 
-func (e *Executor) emptyDryRun(out io.Writer, repos []option.Repo) error {
+func (e *Executor) emptyDryRun(out io.Writer, repos []option.Repo, excludeSet map[string]struct{}) error {
 	var hasError bool
 	for _, repo := range repos {
 		labels, err := e.api.ListLabels(repo)
@@ -443,6 +445,10 @@ func (e *Executor) emptyDryRun(out io.Writer, repos []option.Repo) error {
 		}
 
 		for _, label := range labels {
+			if _, ok := excludeSet[label.Name]; ok {
+				_, _ = fmt.Fprintf(out, "Would skip excluded label %q for repository %q\n", label.Name, repo)
+				continue
+			}
 			_, _ = fmt.Fprintf(out, "Would delete label %q for repository %q\n", label.Name, repo)
 		}
 	}
@@ -452,7 +458,7 @@ func (e *Executor) emptyDryRun(out io.Writer, repos []option.Repo) error {
 	return nil
 }
 
-func (e *Executor) emptyParallel(out io.Writer, repos []option.Repo) error {
+func (e *Executor) emptyParallel(out io.Writer, repos []option.Repo, excludeSet map[string]struct{}) error {
 	wp := NewWorkerPool(out)
 	jobs := make([]Job, len(repos))
 
@@ -460,7 +466,7 @@ func (e *Executor) emptyParallel(out io.Writer, repos []option.Repo) error {
 		jobs[i] = Job{
 			ID: i,
 			Func: func() *JobResult {
-				return e.emptyLabelsForRepo(repo)
+				return e.emptyLabelsForRepo(repo, excludeSet)
 			},
 		}
 	}
@@ -482,7 +488,7 @@ func (e *Executor) emptyParallel(out io.Writer, repos []option.Repo) error {
 	return er.Err()
 }
 
-func (e *Executor) emptyLabelsForRepo(repo option.Repo) *JobResult {
+func (e *Executor) emptyLabelsForRepo(repo option.Repo, excludeSet map[string]struct{}) *JobResult {
 	var output strings.Builder
 	var errors []error
 
@@ -498,6 +504,11 @@ func (e *Executor) emptyLabelsForRepo(repo option.Repo) *JobResult {
 	}
 
 	for _, label := range labels {
+		if _, ok := excludeSet[label.Name]; ok {
+			fmt.Fprintf(&output, "Skipped excluded label %q for repository %q\n", label.Name, repo)
+			continue
+		}
+
 		err := e.api.DeleteLabel(label.Name, repo)
 		if err != nil {
 			fmt.Fprintf(&output, "Failed to delete label %q for repository %q: %v\n", label.Name, repo, err)
@@ -512,6 +523,18 @@ func (e *Executor) emptyLabelsForRepo(repo option.Repo) *JobResult {
 		Success: len(errors) == 0,
 		Errors:  errors,
 	}
+}
+
+func labelSet(labels []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		set[label] = struct{}{}
+	}
+	return set
 }
 
 // Merge merges a source label into a target label across multiple repositories.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -171,7 +171,7 @@ Summary: all operations completed successfully
 			},
 		},
 		{
-			name:   "multiple repository", 
+			name:   "multiple repository",
 			dryrun: false,
 			args: args{
 				repos: []option.Repo{
@@ -1352,20 +1352,21 @@ Summary: 2 repositories succeeded, 1 failed
 
 func TestEmpty(t *testing.T) {
 	type args struct {
-		repos []option.Repo
+		repos         []option.Repo
+		excludeLabels []string
 	}
 	tests := []struct {
-		name    string
-		dryrun  bool
-		args    args
-		mock    *mock.MockAPI
-		wantOut string
-		wantErr bool
-		wantListCall []option.Repo
+		name           string
+		dryrun         bool
+		args           args
+		mock           *mock.MockAPI
+		wantOut        string
+		wantErr        bool
+		wantListCall   []option.Repo
 		wantDeleteCall []struct {
 			Label string
 			Repo  option.Repo
-		}	
+		}
 	}{
 		{
 			name:   "single repository",
@@ -1419,15 +1420,15 @@ Summary: all operations completed successfully
 				ListLabelsFunc: func(repo option.Repo) ([]option.Label, error) {
 					if repo.Owner == "tnagatomi" && repo.Repo == "mock-repo-1" {
 						return []option.Label{
-						{Name: "bug"},
-						{Name: "enhancement"},
-						{Name: "question"},
-					}, nil
+							{Name: "bug"},
+							{Name: "enhancement"},
+							{Name: "question"},
+						}, nil
 					} else if repo.Owner == "tnagatomi" && repo.Repo == "mock-repo-2" {
 						return []option.Label{
-						{Name: "invalid"},
-						{Name: "help wanted"},
-					}, nil
+							{Name: "invalid"},
+							{Name: "help wanted"},
+						}, nil
 					}
 					return nil, fmt.Errorf("unexpected repository: %v", repo)
 				},
@@ -1496,9 +1497,9 @@ Summary: 0 repositories succeeded, 1 failed
 			mock: &mock.MockAPI{
 				ListLabelsFunc: func(repo option.Repo) ([]option.Label, error) {
 					return []option.Label{
-					{Name: "bug"},
-					{Name: "enhancement"},
-				}, nil
+						{Name: "bug"},
+						{Name: "enhancement"},
+					}, nil
 				},
 				DeleteLabelFunc: func(label string, repo option.Repo) error {
 					return &api.ForbiddenError{}
@@ -1595,6 +1596,76 @@ Would delete label "question" for repository "tnagatomi/mock-repo"
 				Repo  option.Repo
 			}{},
 		},
+		{
+			name:   "dry-run excludes protected labels",
+			dryrun: true,
+			args: args{
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
+				excludeLabels: []string{"good first issue"},
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]option.Label, error) {
+					return []option.Label{
+						{Name: "bug"},
+						{Name: "good first issue"},
+					}, nil
+				},
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					return nil
+				},
+			},
+			wantOut: `Would delete label "bug" for repository "tnagatomi/mock-repo"
+Would skip excluded label "good first issue" for repository "tnagatomi/mock-repo"
+`,
+			wantErr: false,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "mock-repo"},
+			},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{},
+		},
+		{
+			name:   "excludes protected labels",
+			dryrun: false,
+			args: args{
+				repos: []option.Repo{
+					{Owner: "tnagatomi", Repo: "mock-repo"},
+				},
+				excludeLabels: []string{"good first issue", "help wanted"},
+			},
+			mock: &mock.MockAPI{
+				ListLabelsFunc: func(repo option.Repo) ([]option.Label, error) {
+					return []option.Label{
+						{Name: "bug"},
+						{Name: "good first issue"},
+						{Name: "help wanted"},
+					}, nil
+				},
+				DeleteLabelFunc: func(label string, repo option.Repo) error {
+					return nil
+				},
+			},
+			wantOut: `Deleted label "bug" for repository "tnagatomi/mock-repo"
+Skipped excluded label "good first issue" for repository "tnagatomi/mock-repo"
+Skipped excluded label "help wanted" for repository "tnagatomi/mock-repo"
+
+Summary: all operations completed successfully
+`,
+			wantErr: false,
+			wantListCall: []option.Repo{
+				{Owner: "tnagatomi", Repo: "mock-repo"},
+			},
+			wantDeleteCall: []struct {
+				Label string
+				Repo  option.Repo
+			}{
+				{Label: "bug", Repo: option.Repo{Owner: "tnagatomi", Repo: "mock-repo"}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1604,7 +1675,7 @@ Would delete label "question" for repository "tnagatomi/mock-repo"
 				dryRun: tt.dryrun,
 			}
 			out := &bytes.Buffer{}
-			err := e.Empty(out, tt.args.repos)
+			err := e.Empty(out, tt.args.repos, tt.args.excludeLabels)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Empty() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Summary

- add `empty --exclude` for comma-separated label names that should be kept
- skip excluded labels in both normal execution and `--dry-run`
- document the new option and cover parsing/executor behavior with tests

Closes #82.

## Validation

- `go test ./cmd -run 'TestParseExcludeLabels|TestRootCmd_Version|TestSyncCmd_MutuallyExclusiveFlags' -count=1`
- `go test ./executor -run TestEmpty -count=1`
- `go test ./cmd -count=1`
- `go test ./...`
- `go build`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached | gitleaks stdin --no-banner --redact --timeout 30`

## Notes

- Exclusions are exact label-name matches after trimming comma-separated CLI input.
- I did not run `golangci-lint run` because `golangci-lint` is not installed locally.
- I did not run E2E tests because they require dedicated GitHub test repositories.
